### PR TITLE
#69 cleanSession flag feature

### DIFF
--- a/src/main/java/st/alr/mqttitude/preferences/PreferencesBroker.java
+++ b/src/main/java/st/alr/mqttitude/preferences/PreferencesBroker.java
@@ -21,6 +21,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
@@ -45,6 +46,7 @@ public class PreferencesBroker extends DialogPreference {
     private Spinner brokerAuth;
     private Spinner clientIdNegotiation;
     private EditText clientId;
+    private CheckBox cleanSession;
 
 
 	private LinearLayout securityWrapper;
@@ -96,6 +98,8 @@ public class PreferencesBroker extends DialogPreference {
 		this.brokerSecuritySSLCaCrtPath = (EditText) root.findViewById(R.id.brokerSecuritySSLCaCrtPath);
         this.clientIdNegotiationAutoOptions = root.findViewById(R.id.clientIdNegotiationAutoOptions);
         this.clientIdNegotiationManualOptions = root.findViewById(R.id.clientIdNegotiationManualOptions);
+        this.cleanSession= (CheckBox) root.findViewById(R.id.cleanSession);
+
 
 		return root;
 	}
@@ -133,6 +137,8 @@ public class PreferencesBroker extends DialogPreference {
         this.clientIdNegotiation.setSelection(Preferences.getZeroLenghClientId() ? 0 : 1);
         this.clientId.setHint(Preferences.getAndroidId());
         this.clientId.setText(Preferences.getClientId(false));
+
+        this.cleanSession.setChecked(Preferences.getCleanSession());
 	}
 
 	@Override
@@ -265,7 +271,7 @@ public class PreferencesBroker extends DialogPreference {
 					}
 				});
 
-	}
+    }
 
     private void handleClientId() {
         boolean auto = this.clientIdNegotiation.getSelectedItemPosition() == 1;
@@ -303,6 +309,7 @@ public class PreferencesBroker extends DialogPreference {
             Preferences.setAuth(this.brokerAuth.getSelectedItemPosition() == 1);
             Preferences.setTls(this.brokerSecurity.getSelectedItemPosition());
             Preferences.setTlsCrtPath(this.brokerSecuritySSLCaCrtPath.getText().toString());
+            Preferences.setCleanSession(this.cleanSession.isChecked());
 
             //Preferences.setClientId(this.clientId.getText().toString());
             //Preferences.setZeroLenghClientId(this.clientIdNegotiation.getSelectedItemPosition() == 1);

--- a/src/main/java/st/alr/mqttitude/services/ServiceBroker.java
+++ b/src/main/java/st/alr/mqttitude/services/ServiceBroker.java
@@ -269,7 +269,7 @@ public class ServiceBroker implements MqttCallback, ProxyableService {
 			// setWill(options);
 			options.setKeepAliveInterval(this.keepAliveSeconds);
 			options.setConnectionTimeout(10);
-			options.setCleanSession(false);
+			options.setCleanSession(Preferences.getCleanSession());
 
 			this.mqttClient.connect(options);
 

--- a/src/main/java/st/alr/mqttitude/support/Preferences.java
+++ b/src/main/java/st/alr/mqttitude/support/Preferences.java
@@ -188,6 +188,13 @@ public class Preferences {
         setBoolean(R.string.keyRemoteCommandDump, aBoolean);
     }
 
+    public static void setCleanSession(boolean aBoolean) {
+        setBoolean(R.string.keyCleanSession, aBoolean);
+    }
+    public static boolean getCleanSession() {
+        return getBoolean(R.string.keyCleanSession,R.bool.valCleanSession);
+    }
+
     public static boolean getConnectionAdvancedMode() {
         return getBoolean(R.string.keyConnectionAdvancedMode, R.bool.valConnectionAdvancedMode);
     }

--- a/src/main/res/layout/preferences_broker.xml
+++ b/src/main/res/layout/preferences_broker.xml
@@ -224,6 +224,21 @@
                 </LinearLayout>
             </FrameLayout>
         </LinearLayout>
+
+       <TextView
+            android:id="@+id/textView10"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/preferencesCleanSessionEnabled" />
+        <CheckBox
+            android:id="@+id/cleanSession"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/preferencesCleanSessionSummary"
+            android:key="@string/keyCleanSession"
+            android:checked="@bool/valCleanSession"/>
+
+
     </LinearLayout>
 
 </ScrollView>

--- a/src/main/res/values/bools.xml
+++ b/src/main/res/values/bools.xml
@@ -7,6 +7,7 @@
 
     <bool name="valPub">false</bool>
     <bool name="valSub">true</bool>
+    <bool name="valCleanSession">false</bool>
     <bool name="valPubIncludeBattery">false</bool>
     <bool name="valNotification">true</bool>
     <bool name="valNotificationGeocoder">true</bool>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -88,6 +88,10 @@
     <string name="preferencesContactsEnabledSummary">Subscribe custom topic</string>
     <string name="preferencesContactsTopic">Subscribe topic</string>
     <string name="preferencesContactsTopicSummary">Custom topic to receive messages</string>
+
+    <string name="preferencesCleanSessionEnabled">Clean Session</string>
+    <string name="preferencesCleanSessionSummary">Enable clean session</string>
+
     <string name="publish">Report</string>
     <string name="preferencesIncludeBatterySummary">Include the device battery level in reports</string>
     <string name="preferencesIncludeBattery">Include battery</string>
@@ -170,6 +174,7 @@
     <string name="keyPubQos">pubQos</string>
     <string name="keyKeepalive">keepalive</string>
     <string name="keyPubRetain">pubRetain</string>
+    <string name="keyCleanSession">cleanSession</string>
     <string name="keyTls">tls</string>
     <string name="keyTlsCrtPath">tlsCrtPath</string>
     <string name="keyLocatorDisplacement">locatorDisplacement</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -102,7 +102,7 @@
             android:key="@string/keySubTopic"
             android:summary="@string/preferencesContactsTopicSummary"
             android:title="@string/preferencesContactsTopic" />
-</PreferenceCategory>
+        </PreferenceCategory>
         <PreferenceCategory android:title="Remote commands">
 
         <CheckBoxPreference
@@ -158,7 +158,7 @@
             android:title="@string/preferencesLocatorAccuracyForeground"
             android:defaultValue="@integer/valLocatorAccuracyForeground"/>
         </PreferenceCategory>
-<PreferenceCategory android:title="Misc">
+        <PreferenceCategory android:title="Misc">
         <CheckBoxPreference
             android:defaultValue="@bool/valUpdateAddressBook"
             android:key="@string/keyUpdateAddressBook"
@@ -176,7 +176,7 @@
             android:key="@string/keyAutostartOnBoot"
             android:summary="@string/preferencesAutostartSummary"
             android:title="@string/preferencesAutostart" />
-</PreferenceCategory>
+        </PreferenceCategory>
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
Enhancement #69. Added checkbox under Preferences/Connections to allow the user to set cleanSession flag.

```
modified:   src/main/java/st/alr/mqttitude/preferences/PreferencesBroker.java
modified:   src/main/java/st/alr/mqttitude/services/ServiceBroker.java
modified:   src/main/java/st/alr/mqttitude/support/Preferences.java
modified:   src/main/res/layout/preferences_broker.xml
modified:   src/main/res/values/bools.xml
modified:   src/main/res/values/strings.xml
```
