### PR TITLE
Added support for User Messages.

### DIFF
--- a/src/main/java/st/alr/mqttitude/messages/UserMessage.java
+++ b/src/main/java/st/alr/mqttitude/messages/UserMessage.java
@@ -1,0 +1,90 @@
+package st.alr.mqttitude.messages;
+
+import android.util.Log;
+
+import org.json.JSONException;
+
+import st.alr.mqttitude.support.StringifiedJSONObject;
+
+public class UserMessage {
+    private String body;
+    private String sender;
+    private String title;
+    private long time;
+
+    private UserMessage(){
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+	public static UserMessage fromJsonObject(StringifiedJSONObject json) {
+		try {
+			String type = json.getString("_type");
+			if (!type.equals("user"))
+				throw new JSONException("wrong type");
+		} catch (JSONException e) {
+			Log.e("UserMessage",
+					"Unable to deserialize UserMessage object from JSON "
+							+ json.toString());
+			return null;
+		}
+
+		UserMessage m = new UserMessage();
+
+		try {
+			m.setBody(json.getString("body"));
+		} catch (Exception e) {
+		    m.setBody("");
+        }
+
+		try {
+			m.setTitle(json.getString("title"));
+		} catch (Exception e) {
+            m.setTitle("");
+		}
+
+        try {
+            m.setSender(json.getString("sender"));
+        } catch (Exception e) {
+            m.setSender("");
+        }
+
+        try {
+            m.setTime(json.getLong("time"));
+        } catch (Exception e) {
+            m.setTime(0);
+        }
+
+		return m;
+	}
+}

--- a/src/main/java/st/alr/mqttitude/services/ServiceBroker.java
+++ b/src/main/java/st/alr/mqttitude/services/ServiceBroker.java
@@ -16,13 +16,10 @@ import java.security.cert.CertificateFactory;
 import java.util.Calendar;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
 
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
@@ -33,16 +30,16 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.MqttPersistenceException;
 import org.eclipse.paho.client.mqttv3.MqttTopic;
-import org.eclipse.paho.client.mqttv3.internal.ClientComms;
 
 import st.alr.mqttitude.R;
 import st.alr.mqttitude.messages.LocationMessage;
+import st.alr.mqttitude.messages.UserMessage;
 import st.alr.mqttitude.support.Defaults;
 import st.alr.mqttitude.support.Defaults.State;
 import st.alr.mqttitude.support.Events;
 import st.alr.mqttitude.support.ServiceMqttCallbacks;
 import st.alr.mqttitude.support.Preferences;
-import android.annotation.SuppressLint;
+
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
@@ -799,7 +796,13 @@ public class ServiceBroker implements MqttCallback, ProxyableService {
                 Log.v(this.toString(), "Received cmd message with unsupported action (" + action + ")");
             }
 
-		} else {
+		} else if(type.equals("user") && topic.equals(Preferences.getBaseTopic())){
+            if(Preferences.getNotificationMessage()) {
+                UserMessage nm = UserMessage.fromJsonObject(json);
+                EventBus.getDefault().postSticky(new Events.NotificationMessageReceived(nm, topic));
+                return;
+            }
+        }else {
 			Log.d(this.toString(), "Ignoring message (" + type + ") received on topic " + topic);
 			return;
 		}

--- a/src/main/java/st/alr/mqttitude/support/Events.java
+++ b/src/main/java/st/alr/mqttitude/support/Events.java
@@ -3,10 +3,12 @@ package st.alr.mqttitude.support;
 import java.util.Date;
 
 import st.alr.mqttitude.db.Waypoint;
+import st.alr.mqttitude.messages.UserMessage;
 import st.alr.mqttitude.messages.WaypointMessage;
 import st.alr.mqttitude.model.Contact;
 import st.alr.mqttitude.model.GeocodableLocation;
 import st.alr.mqttitude.messages.LocationMessage;
+
 import android.location.Location;
 
 public class Events {
@@ -176,6 +178,20 @@ public class Events {
         public WaypointMessage getLocationMessage() {
             return this.m;
         }
+    }
+
+    public static class NotificationMessageReceived extends E{
+        private String t;
+        private UserMessage m;
+
+        public NotificationMessageReceived(UserMessage m, String t){
+            super();
+            this.t = t;
+            this.m = m;
+        }
+
+        public String getTopic() { return this.t; }
+        public UserMessage getNotificationMessage(){ return this.m; }
     }
 
     public static class ContactUpdated extends E {

--- a/src/main/java/st/alr/mqttitude/support/Preferences.java
+++ b/src/main/java/st/alr/mqttitude/support/Preferences.java
@@ -104,6 +104,7 @@ public class Preferences {
                     .put(getStringRessource(R.string.keyNotification), getNotification())
                     .put(getStringRessource(R.string.keyNotificationGeocoder), getNotificationGeocoder())
                     .put(getStringRessource(R.string.keyNotificationLocation), getNotificationLocation())
+                    .put(getStringRessource(R.string.keyUserMessage), getNotificationMessage())
                     .put(getStringRessource(R.string.keyNotificationTickerOnPublish), getNotificationTickerOnPublish())
                     .put(getStringRessource(R.string.keyNotificationTickerOnWaypointTransition), getNotificationTickerOnWaypointTransition())
                     .put(getStringRessource(R.string.keySubTopic), getSubTopic(true))
@@ -154,6 +155,8 @@ public class Preferences {
         try { setNotification(json.getBoolean(getStringRessource(R.string.keyNotification))); } catch (JSONException e) {}
         try { setNotificationGeocoder(json.getBoolean(getStringRessource(R.string.keyNotificationGeocoder))); } catch (JSONException e) {}
         try { setNotificationLocation(json.getBoolean(getStringRessource(R.string.keyNotificationLocation))); } catch (JSONException e) {}
+        try { setNotificationMessage(json.getBoolean(getStringRessource(R.string.keyUserMessage))); } catch (JSONException e) {}
+        try { setNotificationMessageSound(json.getBoolean(getStringRessource(R.string.keyUserMessageSound)));} catch(JSONException e){}
         try { setNotificationTickerOnPublish(json.getBoolean(getStringRessource(R.string.keyNotificationTickerOnPublish))); } catch (JSONException e) {}
         try { setNotificationTickerOnWaypointTransition(json.getBoolean(getStringRessource(R.string.keyNotificationTickerOnWaypointTransition))); } catch (JSONException e) {}
         try { setSubTopic(json.getString(getStringRessource(R.string.keySubTopic))); } catch (JSONException e) {}
@@ -378,7 +381,6 @@ public class Preferences {
         }
     }
 
-
     private static void setPubIncludeBattery(boolean aBoolean) {
         setBoolean(R.string.keyPubIncludeBattery, aBoolean);
     }
@@ -413,6 +415,14 @@ public class Preferences {
 
     private static void setNotificationLocation(boolean aBoolean) {
         setBoolean(R.string.keyNotificationLocation, aBoolean);
+
+    }
+    private static void setNotificationMessage(boolean aBoolean) {
+        setBoolean(R.string.keyUserMessage, aBoolean);
+
+    }
+    private static void setNotificationMessageSound(boolean aBoolean) {
+        setBoolean(R.string.keyUserMessageSound, aBoolean);
 
     }
 
@@ -547,6 +557,14 @@ public class Preferences {
                 R.bool.valNotificationLocation);
     }
 
+    public static boolean getNotificationMessage() {
+        return getBoolean(R.string.keyUserMessage,
+                R.bool.valUserMessage);
+    }
+    public static boolean getNotificationMessageSound() {
+        return getBoolean(R.string.keyUserMessageSound,
+                R.bool.valUserMessageSound);
+    }
     public static int getPubQos() {
         return getInt(
                 R.string.keyPubQos,

--- a/src/main/res/values/bools.xml
+++ b/src/main/res/values/bools.xml
@@ -14,6 +14,8 @@
     <bool name="valNotificationLocation">true</bool>
     <bool name="valNotificationTickerOnWaypointTransition">true</bool>
     <bool name="valNotificationTickerOnPublish">true</bool>
+    <bool name="valUserMessage">true</bool>
+    <bool name="valUserMessageSound">false</bool>
     <bool name="valPubRetain">true</bool>
     <bool name="valAutostartOnBoot">false</bool>
     <bool name="valConnectionAdvancedMode">false</bool>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="preferencesServerConnect">"Connect"</string>
     <string name="preferencesLicenses">"Licenses"</string>
     <string name="preferencesLicensesSummary">"Details for included open-source software"</string>
-    <string name="preferencesNotification">Notifications</string>
+    <string name="preferencesNotification">Notifications</string>preferencesNotification
     <string name="preferencesNotificationTickerOnPublishSummary">Show a ticker on successful reports</string>
     <string name="preferencesNotificationTickerOnPublish">Ticker on report</string>
     <string name="preferencesNotificationTickerOnWaypointTransitionSummary">Show a ticker on waypoint events </string>
@@ -29,6 +29,10 @@
     <string name="preferencesNotificationSummary">"Display a notification to keep running"</string>
     <string name="preferencesNotificationLocationSummary">"Display last reported location and time"</string>
     <string name="preferencesNotificationLocation">"Last reported location"</string>
+    <string name="preferencesUserMessage">"Messages from Broker"</string>
+    <string name="preferencesUserMessageSummary">"Receive user notification messages"</string>
+    <string name="preferencesUserMessageSound">"Play sound on messages"</string>
+    <string name="preferencesUserMessageSoundSummary">"Play default tone on message"</string>
     <string name="preferencesNotificationGeocoderSummary">"Resolve displayed location to addresses"</string>
     <string name="preferencesNotificationGeocoder">"Geocoder"</string>
     <string name="preferencesConnectionAdvancedModeSummary">"Show advanced connection preferences"</string>
@@ -201,6 +205,8 @@
     <string name="keyNotification">notification</string>
     <string name="keyNotificationGeocoder">notificationGeocoder</string>
     <string name="keyNotificationLocation">notificationLocation</string>
+    <string name="keyUserMessage">notificationMessage</string>
+    <string name="keyUserMessageSound">notificationMessageSound</string>
     <string name="keyNotificationTickerOnPublish">notificationTickerOnPublish</string>
     <string name="keyNotificationTickerOnWaypointTransition">tickerOnWaypointTransition</string>
     <string name="keyNotificationOnReceivedWaypointTransition">notificationOnReceivedWaypointTransition</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -79,6 +79,8 @@
             android:key="@string/keyNotificationTickerOnWaypointTransition"
             android:summary="@string/preferencesNotificationTickerOnWaypointTransitionSummary"
             android:title="@string/preferencesNotificationTickerOnWaypointTransitionTitle" />
+
+
     </PreferenceScreen>
     <PreferenceScreen
         android:key="advanced"
@@ -140,6 +142,16 @@
             android:key="@string/keyRemoteConfiguration"
             android:summary="@string/preferencesRemoteConfigurationSummary"
             android:title="@string/preferencesRemoteConfiguration" />
+        <CheckBoxPreference
+            android:defaultValue="@bool/valUserMessage"
+            android:key="@string/keyUserMessage"
+            android:summary="Show user messages sent do topic"
+            android:title="User messages" />
+        <CheckBoxPreference
+            android:defaultValue="@bool/valUserMessageSound"
+            android:key="@string/keyUserMessageSound"
+            android:summary="Play notification sound on user messages"
+            android:title="User message audible notification" />
         </PreferenceCategory>
         <PreferenceCategory android:title="Locator">
 


### PR DESCRIPTION
User Messages are sent to each client topic and are shown in the notification bar.
This is useful as it allows to send simple notifications for users. In my case, I'm using it for custom messages for some event (ex, Friend X is nearby)

The format of each message is the following:
`{"tst": timestamp, "_type": "user", "title": "Message title", "sender": "Message sender", "body": "Message body"}`

If the `"tst"` field is not present, the receiving time will be used.
The `"_type"` field must always be "user" for User Messages.