### PR TITLE
Remove Google Play Services dependency error

### DIFF
--- a/src/main/java/org/owntracks/android/App.java
+++ b/src/main/java/org/owntracks/android/App.java
@@ -7,6 +7,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 
+import org.owntracks.android.activities.ActivityMain;
 import org.owntracks.android.db.ContactLinkDao;
 import org.owntracks.android.db.DaoMaster;
 import org.owntracks.android.db.DaoSession;
@@ -39,6 +40,7 @@ public class App extends Application {
 
     private static App instance;
     private static boolean inForeground;
+    public static Class mapFragmentClass = ActivityMain.MapFragment.class;
     private SimpleDateFormat dateFormater;
 
     private ContactLinkDao contactLinkDao;

--- a/src/main/java/org/owntracks/android/activities/ActivityLauncher.java
+++ b/src/main/java/org/owntracks/android/activities/ActivityLauncher.java
@@ -73,9 +73,7 @@ public class ActivityLauncher extends ActivityBase {
         int resultCode = GooglePlayServicesUtil.isGooglePlayServicesAvailable(App.getContext());
 		playServicesAvailable = ConnectionResult.SUCCESS == resultCode;
 		if (playServicesAvailable) {
-//            App.mapFragmentClass=ActivityMain.GoogleMapFragment.class;
-			App.mapFragmentClass=ActivityMain.MapFragment.class;
-
+            App.mapFragmentClass=ActivityMain.GoogleMapFragment.class;
 		} else {
             Log.e("checkPlayServices", "Google Play services not available. Result code " + resultCode);
             showPlayServicesNotAvilableNotification();

--- a/src/main/java/org/owntracks/android/activities/ActivityLauncher.java
+++ b/src/main/java/org/owntracks/android/activities/ActivityLauncher.java
@@ -1,11 +1,13 @@
 package org.owntracks.android.activities;
 
+import org.owntracks.android.App;
 import org.owntracks.android.R;
 import org.owntracks.android.services.ServiceApplication;
 import org.owntracks.android.services.ServiceProxy;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.app.NotificationManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -15,22 +17,86 @@ import android.content.ServiceConnection;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.support.v4.app.DialogFragment;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 
 public class ActivityLauncher extends ActivityBase {
 	private static final String TAG = "ActivityLauncher";
 
-	private final static int CONNECTION_FAILURE_RESOLUTION_REQUEST = 9000;
+	public final static int CONNECTION_FAILURE_RESOLUTION_REQUEST = 9000;
+	public static boolean playServicesAvailable;
 	private boolean autostart = false;
 
 	private ServiceConnection serviceApplicationConnection;
 	private Context context;
-	private boolean playServicesOk = false;
+
+	private static void showPlayServicesNotAvilableNotification() {
+		NotificationCompat.Builder nb = new NotificationCompat.Builder(
+				App.getContext());
+		NotificationManager nm = (NotificationManager) App.getContext()
+				.getSystemService(NOTIFICATION_SERVICE);
+
+		nb.setContentTitle(App.getContext().getString(R.string.app_name))
+				.setSmallIcon(R.drawable.ic_notification)
+				.setContentText("Google Play Services are not available")
+				.setPriority(NotificationCompat.PRIORITY_MIN);
+		nm.notify(ServiceApplication.NOTIFCATION_ID, nb.build());
+
+	}
+
+	public void showGooglePlayServicesError(int resultCode){
+		Dialog errorDialog = GooglePlayServicesUtil
+				.getErrorDialog(resultCode, this,
+						ActivityLauncher.CONNECTION_FAILURE_RESOLUTION_REQUEST);
+
+		if (errorDialog != null) {
+			// Log.v(TAG, "Showing error recovery dialog");
+			ErrorDialogFragment errorFragment = new ErrorDialogFragment();
+			errorFragment.setDialog(errorDialog);
+
+			FragmentTransaction transaction = getSupportFragmentManager()
+					.beginTransaction();
+			transaction.add(errorFragment,
+					"playServicesErrorFragmentEnable");
+			transaction.commitAllowingStateLoss();
+		}
+	}
+
+
+
+	public static boolean checkPlayServices(ActivityLauncher caller) {
+        int resultCode = GooglePlayServicesUtil.isGooglePlayServicesAvailable(App.getContext());
+		playServicesAvailable = ConnectionResult.SUCCESS == resultCode;
+		if (playServicesAvailable) {
+//            App.mapFragmentClass=ActivityMain.GoogleMapFragment.class;
+			App.mapFragmentClass=ActivityMain.MapFragment.class;
+
+		} else {
+            Log.e("checkPlayServices", "Google Play services not available. Result code " + resultCode);
+            showPlayServicesNotAvilableNotification();
+
+			if (GooglePlayServicesUtil.isUserRecoverableError(resultCode)) {
+                Log.v(TAG, "Showing error recovery dialog");
+				if(caller!=null){
+					caller.showGooglePlayServicesError(resultCode);
+				}
+			} else {
+				if(caller!=null) {
+
+					caller.showQuitError();
+				}
+			}
+        }
+
+        playServicesAvailable=true;
+
+        return playServicesAvailable;
+	}
 
 
 	public static class ErrorDialogFragment extends DialogFragment {
@@ -73,44 +139,8 @@ public class ActivityLauncher extends ActivityBase {
 	protected void onResume() {
 		super.onResume();
 
-		checkPlayServices();
-
-		if (this.playServicesOk)
+		if (checkPlayServices(this))
 			launchChecksComplete();
-	}
-
-	private void checkPlayServices() {
-
-		if (ServiceApplication.checkPlayServices()) {
-			this.playServicesOk = true;
-
-		} else {
-			this.playServicesOk = false;
-			int resultCode = GooglePlayServicesUtil.isGooglePlayServicesAvailable(this);
-
-			Log.e("checkPlayServices", "Google Play services not available. Result code " + resultCode);
-
-			if (GooglePlayServicesUtil.isUserRecoverableError(resultCode)) {
-
-				Dialog errorDialog = GooglePlayServicesUtil
-						.getErrorDialog(resultCode, this,
-								CONNECTION_FAILURE_RESOLUTION_REQUEST);
-
-				if (errorDialog != null) {
-					// Log.v(TAG, "Showing error recovery dialog");
-					ErrorDialogFragment errorFragment = new ErrorDialogFragment();
-					errorFragment.setDialog(errorDialog);
-
-					FragmentTransaction transaction = getSupportFragmentManager()
-							.beginTransaction();
-					transaction.add(errorFragment,
-							"playServicesErrorFragmentEnable");
-					transaction.commitAllowingStateLoss();
-				}
-			} else {
-				showQuitError();
-			}
-		}
 	}
 
 	private void showQuitError() {
@@ -141,7 +171,7 @@ public class ActivityLauncher extends ActivityBase {
 			if (resultCode != RESULT_OK) {
 				Toast.makeText(this, "Google Play Services must be installed.",
 						Toast.LENGTH_SHORT).show();
-				checkPlayServices();
+				checkPlayServices(this);
 			} else {
 				Log.v(TAG, "Play services activated successfully");
 			}

--- a/src/main/java/org/owntracks/android/activities/ActivityMain.java
+++ b/src/main/java/org/owntracks/android/activities/ActivityMain.java
@@ -1,32 +1,9 @@
 package org.owntracks.android.activities;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.owntracks.android.App;
-import org.owntracks.android.R;
-import org.owntracks.android.adapter.ContactAdapter;
-import org.owntracks.android.messages.ClearMessage;
-import org.owntracks.android.messages.CommandMessage;
-import org.owntracks.android.model.Contact;
-import org.owntracks.android.model.GeocodableLocation;
-import org.owntracks.android.services.ServiceBroker;
-import org.owntracks.android.services.ServiceProxy;
-import org.owntracks.android.support.DrawerFactory;
-import org.owntracks.android.support.Events;
-import org.owntracks.android.support.Preferences;
-import org.owntracks.android.support.ReverseGeocodingTask;
-import org.owntracks.android.support.StaticHandler;
-import org.owntracks.android.support.StaticHandlerInterface;
-
 import android.content.Intent;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
@@ -53,7 +30,6 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -73,6 +49,28 @@ import com.google.android.gms.maps.model.MarkerOptions;
 import com.mikepenz.materialdrawer.Drawer;
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem;
 
+import org.owntracks.android.App;
+import org.owntracks.android.R;
+import org.owntracks.android.adapter.ContactAdapter;
+import org.owntracks.android.messages.ClearMessage;
+import org.owntracks.android.messages.CommandMessage;
+import org.owntracks.android.model.Contact;
+import org.owntracks.android.model.GeocodableLocation;
+import org.owntracks.android.services.ServiceBroker;
+import org.owntracks.android.services.ServiceProxy;
+import org.owntracks.android.support.DrawerFactory;
+import org.owntracks.android.support.Events;
+import org.owntracks.android.support.Preferences;
+import org.owntracks.android.support.ReverseGeocodingTask;
+import org.owntracks.android.support.StaticHandler;
+import org.owntracks.android.support.StaticHandlerInterface;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import de.greenrobot.event.EventBus;
 
 public class ActivityMain extends ActivityBase {
@@ -91,6 +89,7 @@ public class ActivityMain extends ActivityBase {
 
     private Toolbar toolbar;
     private Drawer drawer;
+
     @Override
 	protected void onCreate(Bundle savedInstanceState) {
         startService(new Intent(this, ServiceProxy.class));
@@ -111,8 +110,6 @@ public class ActivityMain extends ActivityBase {
 		setContentView(R.layout.activity_main);
         toolbar = (Toolbar)findViewById(R.id.fragmentToolbar);
         setSupportActionBar(toolbar);
-
-
 
 
         final ActivityMain context = this;
@@ -170,6 +167,7 @@ public class ActivityMain extends ActivityBase {
 		FragmentHandler.getInstance().showCurrentOrRoot(this);
 
 	}
+
     @Override
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
@@ -368,7 +366,6 @@ public class ActivityMain extends ActivityBase {
 			FragmentHandler.getInstance().back(this);
 	}
 
-
     private void launchNavigation(Contact c) {
         if(c.getLocation() != null) {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("google.navigation:q=" + c.getLocation().getLatitude() + "," + c.getLocation().getLongitude()));
@@ -451,7 +448,6 @@ public class ActivityMain extends ActivityBase {
 		}
 	}
 
-
     public void share(View view) {
 		ServiceProxy.runOrBind(this, new Runnable() {
 
@@ -479,8 +475,6 @@ public class ActivityMain extends ActivityBase {
         });
 
 	}
-
-
 
 	@Override
 	public void onStart() {
@@ -639,7 +633,6 @@ public class ActivityMain extends ActivityBase {
 		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
 			View v = inflater.inflate(R.layout.fragment_map, container, false);
-
 
 
             this.markerToContacts = new HashMap<String, Contact>();
@@ -810,6 +803,7 @@ public class ActivityMain extends ActivityBase {
         public void centerMap(LatLng latlon, int centerMode, boolean animate) {
             centerMap(latlon, centerMode, animate, -1);
         }
+
 		public void centerMap(LatLng latlon, int centerMode, boolean animate, float zoom) {
             if(centerMode!=SELECT_UPDATE) {
                 CameraUpdate center;
@@ -874,7 +868,6 @@ public class ActivityMain extends ActivityBase {
 			}
 		}
 
-
         public void selectCurrentLocation(final int centerMode, final boolean follow, boolean animate) {
             selectCurrentLocation(centerMode, follow, animate, -1);
         }
@@ -883,6 +876,7 @@ public class ActivityMain extends ActivityBase {
             setFollowingSelectedContact(follow);
             selectCurrentLocation(centerMode, animate, zoom);
         }
+
         public void selectCurrentLocation(final int centerMode, final boolean animate, final float zoom) {
             ServiceProxy.runOrBind(getActivity(), new Runnable() {
 
@@ -945,8 +939,6 @@ public class ActivityMain extends ActivityBase {
             removeContactLocation(e.getContact());
         }
 
-
-
         public void onEventMainThread(Events.CurrentLocationUpdated e) {
             Log.v(TAG,"CurrentLocationUpdated" );
             if(currentLocationMarker != null)
@@ -958,7 +950,6 @@ public class ActivityMain extends ActivityBase {
 //.zIndex(10000).fillColor(R.color.currentLocationRadiusFill).strokeColor(R.color.currentLocationRadiusStroke).
             CircleOptions circleOptions = new CircleOptions().center(e.getGeocodableLocation().getLatLng()).radius(e.getGeocodableLocation().getAccuracy()).strokeWidth(2).strokeColor(0x883f72b5).fillColor(0x110000FF);
             this.currentLocationPrecision = this.googleMap.addCircle(circleOptions);
-
 
 
             if (isFollowingCurrentLocation())
@@ -1126,10 +1117,8 @@ public class ActivityMain extends ActivityBase {
                 @Override
                 public void run() {
                     updateCurrentLocation(ServiceProxy.getServiceLocator().getLastKnownLocation(), true);
-
                 }
             });
-
 		}
 
         @Override
@@ -1139,7 +1128,6 @@ public class ActivityMain extends ActivityBase {
             super.onPause();
 
         }
-
 
 
         @Override
@@ -1161,7 +1149,6 @@ public class ActivityMain extends ActivityBase {
 		}
 
 
-
         @Override
         public void onCreateContextMenu(ContextMenu menu, View v, android.view.ContextMenu.ContextMenuInfo menuInfo) {
             if (v.getId()==R.id.contactsList) {
@@ -1169,16 +1156,11 @@ public class ActivityMain extends ActivityBase {
                 menu.add(Menu.NONE, MENU_CONTACT_DETAILS, 2, R.string.menuContactDetails);
                 menu.add(Menu.NONE, MENU_CONTACT_NAVIGATE, 3, R.string.menuContactNavigate);
                 menu.add(Menu.NONE, MENU_CONTACT_REQUEST_REPORT_LOCATION, 5, R.string.menuContactRequestReportLocation);
-
             }
-
-
-
         }
 
         @Override
-        public boolean onContextItemSelected(MenuItem item)
-        {
+        public boolean onContextItemSelected(MenuItem item) {
             AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo) item.getMenuInfo();
             if(info == null)
                 return true;
@@ -1197,11 +1179,9 @@ public class ActivityMain extends ActivityBase {
                     break;
                 case MENU_CONTACT_REQUEST_REPORT_LOCATION:
                     ((ActivityMain)getActivity()).requestReportLocation(c);
-
             }
             return true;
         }
-
 
 
         @Override
@@ -1226,7 +1206,6 @@ public class ActivityMain extends ActivityBase {
         public void updateCurrentLocation(GeocodableLocation l, boolean resolveGeocoder) {
 			if (l == null)
 				return;
-
 
 
 			if ((l.getGeocoder() == null) && resolveGeocoder) {
@@ -1262,6 +1241,7 @@ public class ActivityMain extends ActivityBase {
 		public void onEventMainThread(Events.ContactUpdated e) {
             updateContactLocation(e.getContact(), true);
 		}
+
         public void onEventMainThread(Events.ContactAdded e) {
 
             listAdapter.addItem(e.getContact());
@@ -1273,7 +1253,6 @@ public class ActivityMain extends ActivityBase {
         }
 
     }
-
 
 
     public static class DetailsFragment extends Fragment  {
@@ -1416,7 +1395,6 @@ public class ActivityMain extends ActivityBase {
 			this.location = (TextView) v.findViewById(R.id.location);
 			this.accuracy = (TextView) v.findViewById(R.id.accuracy);
 			this.time = (TextView) v.findViewById(R.id.time);
-
 
 
             setHasOptionsMenu(true);

--- a/src/main/java/org/owntracks/android/activities/ActivityStatistics.java
+++ b/src/main/java/org/owntracks/android/activities/ActivityStatistics.java
@@ -31,6 +31,7 @@ public class ActivityStatistics extends ActivityBase {
         Toolbar toolbar = (Toolbar) findViewById(R.id.fragmentToolbar);
         setSupportActionBar(toolbar);
         toolbar.setTitle(getTitle());
+
         getSupportActionBar().setDisplayShowTitleEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 

--- a/src/main/java/org/owntracks/android/services/ServiceLocator.java
+++ b/src/main/java/org/owntracks/android/services/ServiceLocator.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.owntracks.android.App;
 import org.owntracks.android.R;
+import org.owntracks.android.activities.ActivityLauncher;
 import org.owntracks.android.db.Waypoint;
 import org.owntracks.android.db.WaypointDao;
 import org.owntracks.android.db.WaypointDao.Properties;
@@ -27,7 +28,6 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.location.Location;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.text.format.DateUtils;
 import android.util.Log;
 
 
@@ -92,16 +92,17 @@ public class ServiceLocator implements ProxyableService, MessageLifecycleCallbac
 
 
         Log.v(TAG, "Checking if Play Services are available");
-        ServiceApplication.checkPlayServices(); // show error notification if  play services were disabled
+        if(ActivityLauncher.checkPlayServices(null)) {
+            ; // show error notification if  play services were disabled
 
-        Log.v(TAG, "Initializing GoogleApiClient");
-        googleApiClient = new GoogleApiClient.Builder(this.context)
-                .addApi(LocationServices.API)
-                .addConnectionCallbacks(this)
-                .addOnConnectionFailedListener(this)
-                .build();
-
-        if(ServiceApplication.checkPlayServices()) {
+            Log.v(TAG, "Initializing GoogleApiClient");
+            googleApiClient = new GoogleApiClient.Builder(this.context)
+                    .addApi(LocationServices.API)
+                    .addConnectionCallbacks(this)
+                    .addOnConnectionFailedListener(this)
+                    .build();
+        }
+        if(ActivityLauncher.checkPlayServices(null)) {
             if (!this.googleApiClient.isConnected() && !this.googleApiClient.isConnecting()) {
                 Log.v(TAG, "Connecting GoogleApiClient");
                 this.googleApiClient.connect();


### PR DESCRIPTION
As a first step for #224, this pull request will remove the blocking error when starting the App, stating that Play Services have to be installed. There is, however, a re-used notification, stating the absence of the services.

The App doesn't crash anymore, it will be usable rudimentary without the services: It can receive and display the Positions and Messages and their details, but it cannot determine the own position and transmit it, it also cannot display the map and the context menu item is removed. So this could be considered a fail-safe listen/read mode.
When run on a device with the GP services installed, everything will run as before, displaying the map and using localisation.

Technically, this has been achieved by harmonising the PlayService checks into only one method, splitting off a GoogleMapFragment as a subclass of MapFragment and using it only when PlayServices are available, otherwise using the generic one.

It would be a good first step to merge, so later commits for LOST introduction won't be too big. This way we can develop and test incrementally and the "Remove" branch/pull request doesn't diverge too much from the master.