### PR TITLE
Upate build.gradle with repo for material-dialogs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
     maven { url 'https://repo.eclipse.org/content/repositories/paho-releases/' }
     maven { url 'http://jcenter.bintray.com'}
     maven { url 'https://maven.fabric.io/public' }
+    maven { url "https://jitpack.io" }
 
     flatDir {
         dirs 'libs'


### PR DESCRIPTION
When checking out a clean copy of the repo to begin building I found
that the gradle sync could not complete as it could not resolve
com.afollestad:material-dialogs:0.7.5.2
The website for that library
(https://github.com/afollestad/material-dialogs) indicates that you need
to add the repo to the build.gradle. (After adding it build works
correctly!)