### PR TITLE
Fix# 304 ServiceBroker ping method had a WakeLock release problem.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 repositories {
     mavenCentral()
 
-    maven { url 'https://repo.eclipse.org/content/repositories/paho-releases/' }
+    maven { url 'https://repo.eclipse.org/content/repositories/paho-snapshots/' }
     maven { url 'http://jcenter.bintray.com'}
     maven { url "https://jitpack.io" }
 
@@ -41,7 +41,7 @@ dependencies {
     compile 'de.greenrobot:greendao:2.0.0'
     compile 'org.altbeacon:android-beacon-library:2.7.1@aar'
     compile 'ch.hsr:geohash:1.1.0'
-    compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.0.2'
+    compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.0.3-SNAPSHOT'
     compile 'com.fasterxml.jackson.core:jackson-core:2.6.2'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.2'
     compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'

--- a/src/main/java/org/owntracks/android/services/ServiceBroker.java
+++ b/src/main/java/org/owntracks/android/services/ServiceBroker.java
@@ -856,12 +856,6 @@ public class ServiceBroker implements MqttCallback, ProxyableService, OutgoingMe
 
         public void ping(Intent intent) {
 			Log.v(TAG, "sending");
-			IMqttToken token = comms.checkForActivity();
-
-			// No ping has been sent.
-			if (token == null) {
-				return;
-			}
 
 			if (wakelock == null) {
 				PowerManager pm = (PowerManager) context.getSystemService(ServiceProxy.POWER_SERVICE);
@@ -871,7 +865,7 @@ public class ServiceBroker implements MqttCallback, ProxyableService, OutgoingMe
 			if(!wakelock.isHeld())
 				wakelock.acquire();
 
-			token.setActionCallback(new IMqttActionListener() {
+			IMqttToken token = comms.checkForActivity(new IMqttActionListener() {
 
 				@Override
 				public void onSuccess(IMqttToken asyncActionToken) {
@@ -891,6 +885,10 @@ public class ServiceBroker implements MqttCallback, ProxyableService, OutgoingMe
 					}
 				}
 			});
+
+			if (token == null) {
+				wakelock.release();
+			}
         }
 
         public PingHandler(Context c) {


### PR DESCRIPTION
Fix #304 

This fix basically applies the fix in the MQTT Paho project:
http://git.eclipse.org/c/paho/org.eclipse.paho.mqtt.java.git/commit/?id=8a9c13def0dee48bbb9aa2a9c576ce0f0fbf250d

Paho 1.0.3 is still not released but I believe this wakelock problem is critical so modified to use the 1.0.3-SNAPSHOT version of MQTT Paho.