### PR TITLE
Added websocket option for private broker

### DIFF
--- a/DaoGenerator/DaoGenerator.iml
+++ b/DaoGenerator/DaoGenerator.iml
@@ -13,7 +13,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/classes/main" />
     <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ android {
         }
     }
     compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    buildToolsVersion '23.0.3'
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 23

--- a/src/main/java/org/owntracks/android/activities/ActivityPreferencesConnection.java
+++ b/src/main/java/org/owntracks/android/activities/ActivityPreferencesConnection.java
@@ -21,6 +21,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.Switch;
 import android.widget.TextView;
@@ -168,12 +169,15 @@ public class ActivityPreferencesConnection extends ActivityBase {
                                     MaterialDialog d = MaterialDialog.class.cast(dialog);
                                     final MaterialEditText host = (MaterialEditText) d.findViewById(R.id.host);
                                     final MaterialEditText port = (MaterialEditText) d.findViewById(R.id.port);
+                                    final CheckBox wsEnable = (CheckBox)d.findViewById(R.id.wsEnable);
 
                                     host.setText(Preferences.getHost());
                                     host.setFloatingLabelAlwaysShown(true);
 
                                     port.setText(Preferences.getPortWithHintSupport());
                                     port.setFloatingLabelAlwaysShown(true);
+
+                                    wsEnable.setChecked(Preferences.getWs());
 
                                 }
                             })
@@ -184,6 +188,7 @@ public class ActivityPreferencesConnection extends ActivityBase {
                                     MaterialDialog d = MaterialDialog.class.cast(dialog);
                                     final MaterialEditText host = (MaterialEditText) d.findViewById(R.id.host);
                                     final MaterialEditText port = (MaterialEditText) d.findViewById(R.id.port);
+                                    final CheckBox wsEnable = (CheckBox)d.findViewById(R.id.wsEnable);
 
 
                                     Preferences.setHost(host.getText().toString());
@@ -192,6 +197,8 @@ public class ActivityPreferencesConnection extends ActivityBase {
                                     } catch (NumberFormatException e) {
                                         Preferences.clearKey(Preferences.Keys.PORT);
                                     }
+
+                                    Preferences.setWs(wsEnable.isChecked());
                                 }
                             })
 

--- a/src/main/java/org/owntracks/android/services/ServiceBroker.java
+++ b/src/main/java/org/owntracks/android/services/ServiceBroker.java
@@ -374,7 +374,18 @@ public class ServiceBroker implements MqttCallback, ProxyableService, OutgoingMe
 		}
 
 		try {
-			String prefix = Preferences.getTls() ? "ssl" : "tcp";
+			String prefix = "tcp";
+
+			if (Preferences.getTls()) {
+				if (Preferences.getWs())
+					prefix = "wss";
+				else
+					prefix = "ssl";
+			} else {
+				if (Preferences.getWs())
+					prefix = "ws";
+			}
+
 			String cid = Preferences.getClientId(true);
             String connectString = prefix + "://" + Preferences.getHost() + ":" + Preferences.getPort();
 			Log.v(TAG, "init() mode: " + Preferences.getModeId());

--- a/src/main/java/org/owntracks/android/support/Preferences.java
+++ b/src/main/java/org/owntracks/android/support/Preferences.java
@@ -789,6 +789,11 @@ public class Preferences {
         setBoolean(Keys.TLS, tlsSpecifier, false);
     }
 
+    @Import(key =Keys.WS)
+    public static void setWs(boolean wsEnable) {
+        setBoolean(Keys.WS, wsEnable, false);
+    }
+
     public static void setTlsCaCrt(String name) {
         setString(Keys.TLS_CA_CRT, name, false);
     }
@@ -807,6 +812,10 @@ public class Preferences {
     @Export(key =Keys.TLS, exportModeMqttPrivate =true)
     public static boolean getTls() {
         return getBoolean(Keys.TLS, R.bool.valTls, R.bool.valTlsPublic, true);
+    }
+    @Export(key =Keys.WS, exportModeMqttPrivate =true)
+    public static boolean getWs() {
+        return getBoolean(Keys.WS, R.bool.valWs, R.bool.valWsDisable, true);
     }
 
     @Export(key =Keys.TLS_CA_CRT, exportModeMqttPrivate =true)
@@ -1025,6 +1034,7 @@ public class Preferences {
         public static final String _ENCRYPTION_KEY                  = "encryptionKey";
         public static final String _FIST_START                      = "fistStart";
 
+        public static final String WS = "ws";
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/res/layout/preferences_host.xml
+++ b/src/main/res/layout/preferences_host.xml
@@ -36,4 +36,11 @@
         app:met_floatingLabelAlwaysShown="true"
 
         />
+
+    <CheckBox
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/preferencesWebsocket"
+        android:id="@+id/wsEnable"
+        android:checked="false" />
 </LinearLayout>

--- a/src/main/res/values/bools.xml
+++ b/src/main/res/values/bools.xml
@@ -2,4 +2,6 @@
 <resources>
     <bool name="valTrue">true</bool>
     <bool name="valFalse">false</bool>
+    <bool name="valWsEnable">true</bool>
+    <bool name="valWsDisable">false</bool>
 </resources>

--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -62,6 +62,7 @@
     <bool name="valRemoteConfiguration">true</bool>
     <bool name="valBeaconRangingEnabled">false</bool>
     <bool name="valTls">true</bool>
+    <bool name="valWs">false</bool>
     <bool name="valInfo" >true</bool>
 
     <string-array name="modeIds">

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="preferencesServer">"Connection"</string>
     <string name="preferencesHost">"Host"</string>
     <string name="preferencesPort">"Port"</string>
+    <string name="preferencesWebsocket">Use WebSocket protocol</string>
     <string name="preferencesUserUsername">"Username"</string>
     <string name="preferencesDeviceName">"Device ID"</string>
     <string name="preferencesConnectionSecurity">"Connection security"</string>
@@ -277,6 +278,7 @@
     <string name="exportWaypointsToEndpointSummary">export waypoints to endpoints</string>
     <string name="preferencesExportFailed">Preferences export failed</string>
     <string name="preferencesExportSuccess">Export successfull</string>
+    <string name="wsLabel">Use WebSocket protocol</string>
 
     <string-array name="filepicker">
         <item>Select</item>


### PR DESCRIPTION
Added a checkbox in Host preferences to use websocket protocol to the broker. I needed this because OpenShift (openshift.redhat.com) exposes only HTTP or websocket ports and not the standard MQTT port.