### PR TITLE
Some project changes to make the app debug-buildable again

### DIFF
--- a/project/app/build.gradle
+++ b/project/app/build.gradle
@@ -104,6 +104,8 @@ dependencies {
     compile 'me.tatarka.bindingcollectionadapter:bindingcollectionadapter-recyclerview:1.1.0'
     compile 'com.jakewharton.timber:timber:4.1.2'
 
+    compile 'org.antlr:antlr4-runtime:4.5.3'
+
     // Widget libraries
     compile 'com.github.rengwuxian:MaterialEditText:2.1.4'
     compile('com.mikepenz:fastadapter:1.1.2@aar') {

--- a/project/gradle/wrapper/gradle-wrapper.properties
+++ b/project/gradle/wrapper/gradle-wrapper.properties
@@ -1,1 +1,6 @@
 #Mon Dec 28 10:00:20 PST 2015
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
As mentioned in #395, here are the changes to make the project buildable again.
It solves the mentioned problems 2 and 3, while problem 1 can be circumvented by opening the project in the sub-folder.
Problem 4 is not solved though, so you can't build a release .apk currently (build fails because of Warnings). You CAN however build a debug apk and push it to the phone.