### PR TITLE
Check http response for success

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/services/ServiceMessageHttp.java
+++ b/project/app/src/main/java/org/owntracks/android/services/ServiceMessageHttp.java
@@ -240,8 +240,7 @@ public class ServiceMessageHttp implements StatelessMessageEndpoint, OutgoingMes
         try {
              Response r = mHttpClient.newCall(request.build()).execute();
 
-             //We got a response, treat as delivered successful
-             if(r != null ) {
+             if((r != null) && (r.isSuccessful())) {
                  Timber.v("got HTTP response");
 
                  try {


### PR DESCRIPTION
Hi,

According to documentation (http://owntracks.org/booklet/tech/http/#http),  there is a mismatch between iOS and Android, where on iOS only response 2xx is considered OK, but on Android any response is considered OK.

I created this pull request as a suggestion on how to fix it, as my backend (not finished and too ashamed to share yet) sometimes fails and will then return a 501 error when a client tries to send updates.

Ref. documentation on okhttp: http://square.github.io/okhttp/3.x/okhttp/okhttp3/Response.html#isSuccessful--

This is my first pull request to this project, so please let me know how to improve in the future :)