### PR TITLE
Move Google Maps API Key to a gradle variable

### DIFF
--- a/project/app/build.gradle
+++ b/project/app/build.gradle
@@ -36,6 +36,7 @@ android {
             shrinkResources true
             zipAlignEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            resValue "string", "GOOGLE_MAPS_API_KEY", "${google_maps_api_key}"
         }
 
         debug {
@@ -43,6 +44,7 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             applicationIdSuffix '.debug'
+            resValue "string", "GOOGLE_MAPS_API_KEY", "${google_maps_api_key}"
         }
     }
 

--- a/project/app/gradle.properties
+++ b/project/app/gradle.properties
@@ -1,0 +1,1 @@
+google_maps_api_key=PLACEHOLDER_API_KEY

--- a/project/app/src/main/res/values/apis.xml
+++ b/project/app/src/main/res/values/apis.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="GOOGLE_MAPS_API_KEY" translatable="false">YOUR_GOOGLE_MAPS_API_KEY</string>
-</resources>


### PR DESCRIPTION
To allow easy testing and builds with dev's own API key, move the key
resource into a gradle property. The default is in the gradle.properties
file, but will be overridden by the local
`$GRADLE_USER_HOME/gradle.properties`, a command line switch or env var
(see https://docs.gradle.org/current/userguide/build_environment.html)

Basically means that I can have my own API key in my user gradle config
without worrying about remembering to not commit it. For releases, I
guess the prod key can just be configered in the environment, or
supplied as a cli switch.