### PR TITLE
Modify reportLocation to cause a live location lookup.

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
@@ -42,6 +42,13 @@ public class LocationProcessor {
     public static final int MONITORING_SIGNIFFICANT = 1;
     public static final int MONITORING_MOVE = 2;
 
+    public interface LocationProvider {
+        void OnDemandLocationRequest();
+    }
+
+    LocationProvider m_locationProvider = null;
+
+
     @Inject
     public LocationProcessor(MessageProcessor messageProcessor, Preferences preferences, LocationRepo locationRepo, WaypointsRepo waypointsRepo, DeviceMetricsProvider deviceMetricsProvider) {
         this.messageProcessor = messageProcessor;
@@ -132,10 +139,10 @@ public class LocationProcessor {
         return l;
     }
 
-    public void onLocationChanged(@NonNull Location l) {
+    public void onLocationChanged(@NonNull Location l, @Nullable String reportType) {
         locationRepo.setCurrentLocation(l);
 
-        publishLocationMessage(MessageLocation.REPORT_TYPE_DEFAULT);
+        publishLocationMessage(reportType);
     }
 
 
@@ -204,5 +211,17 @@ public class LocationProcessor {
         }
         message.setWaypoints(collection);
         messageProcessor.sendMessage(message);
+    }
+
+
+    public void setLocationProvider(LocationProvider provider) {
+        m_locationProvider = provider;
+    }
+
+
+    public void OnDemandLocationRequest() {
+        if (m_locationProvider != null) {
+            m_locationProvider.OnDemandLocationRequest();
+        }
     }
 }

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
@@ -331,7 +331,7 @@ public class MessageProcessor implements IncomingMessageProcessor {
                         Timber.e("command not supported in HTTP mode: %s", cmd);
                         break;
                     }
-                    locationProcessorLazy.get().publishLocationMessage(MessageLocation.REPORT_TYPE_RESPONSE);
+                    locationProcessorLazy.get().OnDemandLocationRequest();
                     break;
                 case MessageCmd.ACTION_WAYPOINTS:
                     locationProcessorLazy.get().publishWaypointsMessage();


### PR DESCRIPTION
This change is in relation to issue 660. It modifies the reportLocation command to cause a live location update. The new logic path makes use of the existing publishLocationMessage method and as such honors the logic surrounding privacy.

Side note, this is my first time working with Android code. I look forward to hearing your comments and suggestions for improvement.
