### PR TITLE
Region lat/lng databinding via string

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/data/WaypointModel.java
+++ b/project/app/src/main/java/org/owntracks/android/data/WaypointModel.java
@@ -70,18 +70,48 @@ public class WaypointModel extends BaseObservable {
     }
 
     @Bindable
+    public String getGeofenceLatitudeAsStr() {
+        return String.valueOf(geofenceLatitude);
+    }
+
+    @Bindable
     public double getGeofenceLatitude() {
         return geofenceLatitude;
+    }
+
+    public void setGeofenceLatitudeAsStr(String geofenceLatitudeAsStr) {
+        try {
+            double geofenceLatitude = Double.parseDouble(geofenceLatitudeAsStr);
+            setGeofenceLatitude(geofenceLatitude);
+        } catch (NumberFormatException e) {
+            // User has entered something that can't be converted to a double
+            // TODO: figure out validation feeback
+        }
     }
 
     public void setGeofenceLatitude(double geofenceLatitude) {
         if(geofenceLatitude > 90)
             this.geofenceLatitude = 90;
-        if(geofenceLatitude < -90)
+        else if(geofenceLatitude < -90)
             this.geofenceLatitude = -90;
         else
             this.geofenceLatitude = geofenceLatitude;
         notifyPropertyChanged(BR.geofenceLatitude);
+    }
+
+    @Bindable
+    public String getGeofenceLongitudeAsStr() {
+        return String.valueOf(geofenceLongitude);
+    }
+
+    public void setGeofenceLongitudeAsStr(String geofenceLongitudeAsStr) {
+        try {
+            double geofenceLatitude = Double.parseDouble(geofenceLongitudeAsStr);
+            setGeofenceLongitude(geofenceLatitude);
+        } catch (NumberFormatException e) {
+            // User has entered something that can't be converted to a double
+            // TODO: figure out validation feeback
+        }
     }
 
     @Bindable
@@ -92,7 +122,7 @@ public class WaypointModel extends BaseObservable {
     public void setGeofenceLongitude(double geofenceLongitude) {
         if(geofenceLongitude > 180 )
             this.geofenceLongitude = 180 ;
-        if(geofenceLongitude < -180 )
+        else if(geofenceLongitude < -180 )
             this.geofenceLongitude = -180 ;
         else
             this.geofenceLongitude = geofenceLongitude;

--- a/project/app/src/main/java/org/owntracks/android/support/widgets/BindingConversions.java
+++ b/project/app/src/main/java/org/owntracks/android/support/widgets/BindingConversions.java
@@ -50,12 +50,6 @@ public class BindingConversions {
     }
 
     @BindingConversion
-    @InverseMethod("convertToDouble")
-    public static String convertToString(@Nullable Double d) {
-        return d != null ? d.toString() : EMPTY_STRING;
-    }
-
-    @BindingConversion
     public static String convertToString(String s) {
         return s != null ? s : EMPTY_STRING;
     }
@@ -75,15 +69,6 @@ public class BindingConversions {
     public static Integer convertToIntegerZeroIsEmpty(String d) {
         return convertToInteger(d);
     }
-
-
-    // XX to Double
-    @BindingConversion
-    @Nullable
-    public static Double convertToDouble(@Nullable String d) {
-        return d != null ? Double.parseDouble(d) : null;
-    }
-
 
     // Misc
     @BindingAdapter({"android:text"})

--- a/project/app/src/main/res/layout/ui_region.xml
+++ b/project/app/src/main/res/layout/ui_region.xml
@@ -35,12 +35,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:layout_marginEnd="@dimen/default_spacing"
-                android:layout_marginRight="@dimen/default_spacing">
+                android:layout_marginEnd="@dimen/default_spacing">
                 <com.rengwuxian.materialedittext.MaterialEditText
                     android:layout_marginTop="20dp"
                     android:layout_width="match_parent"
-                    android:layout_marginLeft="@dimen/default_spacing"
                     android:layout_marginStart="@dimen/default_spacing"
                     android:layout_height="wrap_content"
                     android:hint="@string/description"
@@ -56,34 +54,32 @@
 
                 <com.rengwuxian.materialedittext.MaterialEditText
                     android:layout_marginTop="20dp"
-                    android:layout_marginLeft="@dimen/default_spacing"
                     android:layout_marginStart="@dimen/default_spacing"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/latitude"
+                    android:enabled="true"
+                    android:id="@+id/latitude"
+                    android:text="@={vm.waypoint.geofenceLatitudeAsStr}"
+                    android:inputType="numberDecimal|numberSigned"
                     app:met_floatingLabel="normal"
                     app:met_baseColor="@color/textPrimary"
                     app:met_primaryColor="@color/accent"
-                    android:enabled="true"
-                    android:id="@+id/latitude"
-                    android:text="@={org.owntracks.android.support.widgets.BindingConversions.convertToString(vm.waypoint.geofenceLatitude)}"
-                    android:inputType="numberDecimal"
                     />
 
                 <com.rengwuxian.materialedittext.MaterialEditText
-                    android:layout_marginLeft="@dimen/default_spacing"
                     android:layout_marginStart="@dimen/default_spacing"
                     android:layout_marginTop="20dp"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/longitude"
+                    android:enabled="true"
+                    android:id="@+id/longitude"
+                    android:text="@={vm.waypoint.geofenceLongitudeAsStr}"
+                    android:inputType="numberDecimal|numberSigned"
                     app:met_floatingLabel="normal"
                     app:met_baseColor="@color/textPrimary"
                     app:met_primaryColor="@color/accent"
-                    android:enabled="true"
-                    android:id="@+id/longitude"
-                    android:text="@={org.owntracks.android.support.widgets.BindingConversions.convertToString(vm.waypoint.geofenceLongitude)}"
-                    android:inputType="numberDecimal"
                     />
 
                 <com.rengwuxian.materialedittext.MaterialEditText


### PR DESCRIPTION
Currently, if you try and backspace in a lat/lng field on the region picker, the UI behaves oddly. Whatever the value of the field, it converts to a double and then the field is updated to this value. This means that attempts to backspace the decimal point fail (a double representation is always "x.y").

Rather than databinding to the double directly, this should go via a string method that does the double validation. This allows the user to momentarily input something that isn't a valid double without forcing an update to the UI. What's still to remain is to provide feedback to the user by setting field.error() if the number isn't a valid entry (valid and in range). Values are currently silently fixed or ignored if they're outside the range.

Also closes issue #740 and allows negative numbers.