### PR TITLE
Allow user-configurable interval in move mode

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
@@ -293,7 +293,6 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
         notificationManager.createNotificationChannel(eventsChannel);
     }
 
-
     @Nullable
     private NotificationCompat.Builder getOngoingNotificationBuilder() {
         if (activeNotificationCompatBuilder != null)
@@ -336,8 +335,6 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
 
         return activeNotificationCompatBuilder;
     }
-
-
 
     private void updateOngoingNotification() {
         notificationManager.notify(NOTIFICATION_ID_ONGOING,getOngoingNotification());
@@ -565,20 +562,16 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
             case LocationProcessor.MONITORING_QUIET:
             case LocationProcessor.MONITORING_MANUAL:
                 request.setInterval(TimeUnit.SECONDS.toMillis(preferences.getLocatorInterval()));
-                request.setFastestInterval(TimeUnit.SECONDS.toMillis(10));
                 request.setSmallestDisplacement(preferences.getLocatorDisplacement());
                 request.setPriority(LocationRequest.PRIORITY_LOW_POWER);
                 break;
             case LocationProcessor.MONITORING_SIGNIFFICANT:
                 request.setInterval(TimeUnit.SECONDS.toMillis(preferences.getLocatorInterval()));
-                request.setFastestInterval(TimeUnit.SECONDS.toMillis(10));
                 request.setSmallestDisplacement(preferences.getLocatorDisplacement());
                 request.setPriority(getLocationRequestPriority());
-
                 break;
             case LocationProcessor.MONITORING_MOVE:
-                request.setInterval(TimeUnit.SECONDS.toMillis(30));
-                request.setFastestInterval(TimeUnit.SECONDS.toMillis(10));
+                request.setInterval(TimeUnit.SECONDS.toMillis(preferences.getMoveModeLocatorInterval()));
                 request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
                 break;
         }
@@ -748,7 +741,6 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
 
     }
 
-
     private NotificationCompat.Builder getEventsNotificationBuilder() {
         if (!preferences.getNotificationEvents())
             return null;
@@ -782,7 +774,6 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
         return eventsNotificationCompatBuilder;
     }
 
-
     @Override
     public void onComplete(@NonNull Task<Location> task) {
         onLocationChanged(task.getResult(),MessageLocation.REPORT_TYPE_DEFAULT);
@@ -797,13 +788,15 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (Preferences.Keys.LOCATOR_INTERVAL.equals(key) || Preferences.Keys.LOCATOR_DISPLACEMENT.equals(key) || Preferences.Keys.LOCATOR_PRIORITY.equals(key)) {
+        if (Preferences.Keys.LOCATOR_INTERVAL.equals(key) ||
+                Preferences.Keys.LOCATOR_DISPLACEMENT.equals(key) ||
+                Preferences.Keys.LOCATOR_PRIORITY.equals(key) ||
+                Preferences.Keys.LOCATOR_INTERVAL_MOVE_MODE.equals(key)
+        ) {
             Timber.v("locator preferences changed. Resetting location request.");
             setupLocationRequest();
         }
     }
-
-
 
     public class LocalBinder extends Binder {
         public BackgroundService getService() {

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointMqtt.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointMqtt.java
@@ -101,7 +101,7 @@ public class MessageProcessorEndpointMqtt extends MessageProcessorEndpoint imple
 			messageProcessor.onMessageDeliveryFailed(messageId);
 		} catch (Exception e) {
 			// Message will not contain BUNDLE_KEY_ACTION and will be dropped by scheduler
-			Timber.e(e, "JSON serialization failed for message %m. Message will be dropped", m.getMessageId());
+			Timber.e(e, "JSON serialization failed for message %s. Message will be dropped", m.getMessageId());
 			messageProcessor.onMessageDeliveryFailedFinal(messageId);
 		}
 	}

--- a/project/app/src/main/java/org/owntracks/android/support/Events.java
+++ b/project/app/src/main/java/org/owntracks/android/support/Events.java
@@ -1,9 +1,9 @@
 package org.owntracks.android.support;
 
-import java.util.Date;
-
 import org.owntracks.android.data.WaypointModel;
 import org.owntracks.android.model.FusedContact;
+
+import java.util.Date;
 
 public class Events {
     public static abstract class E {
@@ -142,5 +142,4 @@ public class Events {
             return this.fusedContact;
         }
     }
-
 }

--- a/project/app/src/main/java/org/owntracks/android/support/Preferences.java
+++ b/project/app/src/main/java/org/owntracks/android/support/Preferences.java
@@ -284,8 +284,6 @@ public class Preferences {
         Timber.v("committing to preferences %s", activeSharedPreferences);
 
         activeSharedPreferences.edit().commit();
-
-
     }
 
     @Export(key = Keys.MONITORING, exportModeMqttPrivate = true, exportModeHttpPrivate = true)
@@ -384,6 +382,11 @@ public class Preferences {
     @Export(key =Keys.LOCATOR_INTERVAL, exportModeMqttPrivate =true, exportModeHttpPrivate =true)
     public int getLocatorInterval() {
         return getInt(Keys.LOCATOR_INTERVAL, R.integer.valLocatorInterval);
+    }
+
+    @Export(key =Keys.LOCATOR_INTERVAL_MOVE_MODE, exportModeMqttPrivate =true, exportModeHttpPrivate =true)
+    public int getMoveModeLocatorInterval() {
+        return getInt(Keys.LOCATOR_INTERVAL_MOVE_MODE, R.integer.valMoveModeLocatorInterval);
     }
 
     @Export(key =Keys.LOCATOR_PRIORITY, exportModeMqttPrivate =true, exportModeHttpPrivate =true)
@@ -687,7 +690,6 @@ public class Preferences {
     @Import(key =Keys.LOCATOR_INTERVAL)
     private void setLocatorInterval(int anInt) {
         setInt(Keys.LOCATOR_INTERVAL, anInt);
-
     }
 
     @Import(key =Keys.LOCATOR_DISPLACEMENT)
@@ -795,7 +797,6 @@ public class Preferences {
     public boolean getNotificationHigherPriority() {
         return getBoolean(Keys.NOTIFICATION_HIGHER_PRIORITY, R.bool.valNotificationHigherPriority);
     }
-
 
     @Export(key =Keys.NOTIFICATION_LOCATION, exportModeMqttPrivate =true)
     public  boolean getNotificationLocation() {
@@ -939,8 +940,6 @@ public class Preferences {
         sharedPreferences.edit().putBoolean(Keys._OBJECTBOX_MIGRATED, true).apply();
     }
 
-
-
     @SuppressWarnings("WeakerAccess")
     public static class Keys {
         public static final String AUTH                             = "auth";
@@ -958,6 +957,7 @@ public class Preferences {
         public static final String KEEPALIVE                        = "keepalive";
         public static final String LOCATOR_DISPLACEMENT             = "locatorDisplacement";
         public static final String LOCATOR_INTERVAL                 = "locatorInterval";
+        public static final String LOCATOR_INTERVAL_MOVE_MODE       = "moveModeLocatorInterval";
         public static final String LOCATOR_PRIORITY                 = "locatorPriority";
         public static final String MODE_ID                          = "mode";
         public static final String MONITORING                       = "monitoring";
@@ -994,9 +994,7 @@ public class Preferences {
         public static final String _FIRST_START                     = "firstStart";
         public static final String _SETUP_NOT_COMPLETED             = "setupNotCompleted";
         public static final String _VERSION                         = "_build";
-
-        public static final String _OBJECTBOX_MIGRATED                     = "_objectboxMigrated";
-
+        public static final String _OBJECTBOX_MIGRATED              = "_objectboxMigrated";
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/project/app/src/main/java/org/owntracks/android/ui/preferences/PreferencesFragment.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/preferences/PreferencesFragment.java
@@ -200,6 +200,8 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
         PreferenceCategory locator = getCategory(R.string.preferencesCategoryAdvancedLocator);
         screen.addPreference(locator);
         addEditIntegerPreference(locator, Preferences.Keys.IGNORE_INACCURATE_LOCATIONS, R.string.preferencesIgnoreInaccurateLocations, R.integer.valIgnoreInaccurateLocations).withPreferencesSummary(R.string.preferencesIgnoreInaccurateLocationsSummary).withDialogMessage(R.string.preferencesIgnoreInaccurateLocationsDialog);
+        addEditIntegerPreference(locator, Preferences.Keys.LOCATOR_INTERVAL, R.string.preferencesLocatorInterval, R.integer.valLocatorInterval).withPreferencesSummary(R.string.preferencesLocatorIntervalSummary).withDialogMessage(R.string.preferencesLocatorIntervalDialog);
+        addEditIntegerPreference(locator, Preferences.Keys.LOCATOR_INTERVAL_MOVE_MODE, R.string.preferencesMoveModeLocatorInterval, R.integer.valMoveModeLocatorInterval).withPreferencesSummary(R.string.preferencesMoveModeLocatorIntervalSummary).withDialogMessage(R.string.preferencesMoveModeLocatorIntervalDialog);
 
         PreferenceCategory encryption = getCategory(R.string.preferencesCategoryAdvancedEncryption);
         screen.addPreference(encryption);

--- a/project/app/src/main/res/values/defaults.xml
+++ b/project/app/src/main/res/values/defaults.xml
@@ -9,6 +9,7 @@
     <integer name="valKeepalive">3600</integer>
     <integer name="valLocatorDisplacement">500</integer>
     <integer name="valLocatorInterval">900</integer>
+    <integer name="valMoveModeLocatorInterval">10</integer>
     <integer name="valIgnoreStaleLocations">0</integer>
     <integer name="valIgnoreInaccurateLocations">0</integer>
     <integer name="valModeId">0</integer>

--- a/project/app/src/main/res/values/strings.xml
+++ b/project/app/src/main/res/values/strings.xml
@@ -116,6 +116,13 @@
     <string name="preferencesIgnoreInaccurateLocations">Inaccurate locations</string>
     <string name="preferencesIgnoreInaccurateLocationsSummary">Ignore inaccurate locations</string>
     <string name="preferencesIgnoreInaccurateLocationsDialog">Ignore location, if the accuracy is greater than the given meters</string>
+    <string name="preferencesLocatorInterval">Location interval</string>
+    <string name="preferencesLocatorIntervalSummary">Interval between location updates</string>
+    <string name="preferencesLocatorIntervalDialog">How often should locations be requested from the device</string>
+    <string name="preferencesMoveModeLocatorInterval">Location interval (Move mode)</string>
+    <string name="preferencesMoveModeLocatorIntervalSummary">Interval between location updates in Move mode</string>
+    <string name="preferencesMoveModeLocatorIntervalDialog">How often should locations be requested from the device whilst in Move mode</string>
+
     <string name="errorPreferencesImportFailedMemory">Your device ran out of memory</string>
     <string name="noNavigationApp">no suitable app installed</string>
     <string name="menuClear">Clear</string>


### PR DESCRIPTION
For issue #778, allow the user to configure the locator interval for
Move mode, keeping the default at the old hard-coded value of 10.

Also surface both locator interval configuration options in the Advanced
config UI.