### PR TITLE
Simplified message queue handling

### DIFF
--- a/project/app/src/main/AndroidManifest.xml
+++ b/project/app/src/main/AndroidManifest.xml
@@ -175,6 +175,8 @@
             </intent-filter>
         </service>
 
+        <service android:name="com.ibm.android.service.MqttService" />
+
         <receiver
             android:name=".support.receiver.BootCompleteReceiver"
             android:enabled="true"

--- a/project/app/src/main/java/org/owntracks/android/injection/components/AppComponentProvider.java
+++ b/project/app/src/main/java/org/owntracks/android/injection/components/AppComponentProvider.java
@@ -1,7 +1,5 @@
 package org.owntracks.android.injection.components;
 
-import org.owntracks.android.injection.components.AppComponent;
-
 public class AppComponentProvider {
     private static AppComponent appComponent;
 

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageBase.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageBase.java
@@ -111,10 +111,7 @@ public abstract class MessageBase extends BaseObservable  {
         }
 
         @JsonIgnore
-        protected abstract void processIncomingMessage(IncomingMessageProcessor handler);
-
-        @JsonIgnore
-        protected abstract void processOutgoingMessage(OutgoingMessageProcessor handler);
+        public abstract void processIncomingMessage(IncomingMessageProcessor handler);
 
         @JsonIgnore
         protected abstract String getBaseTopicSuffix();

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageBase.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageBase.java
@@ -10,9 +10,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-
-import java.lang.ref.WeakReference;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type", defaultImpl = MessageUnknown.class)
 
@@ -38,10 +35,10 @@ public abstract class MessageBase extends BaseObservable  {
         private String _topic_base;
 
         @JsonIgnore
-        private boolean delivered;
+        private int modeId;
 
         @JsonIgnore
-        private int modeId;
+        private boolean incoming = false;
 
         @JsonIgnore
         public long getMessageId() {
@@ -78,12 +75,6 @@ public abstract class MessageBase extends BaseObservable  {
         }
 
         @JsonIgnore
-        private WeakReference<IncomingMessageProcessor> _processorIn;
-
-        @JsonIgnore
-        private WeakReference<OutgoingMessageProcessor> _processorOut;
-
-        @JsonIgnore
         @NonNull
         public String getContactKey() {
                 if(_topic_base != null)
@@ -105,9 +96,8 @@ public abstract class MessageBase extends BaseObservable  {
         }
 
         @JsonIgnore
-        public void setIncomingProcessor(@NonNull IncomingMessageProcessor processor) {
-                this._processorOut = null;
-                this._processorIn = new WeakReference<>(processor);
+        public void setIncoming() {
+                this.incoming = true;
         }
 
         @JsonIgnore
@@ -125,12 +115,7 @@ public abstract class MessageBase extends BaseObservable  {
 
         @JsonIgnore
         public boolean isIncoming() {
-                return this._processorIn != null;
-        }
-
-        @JsonIgnore
-        public boolean isOutgoing() {
-                return this._processorOut != null;
+                return this.incoming;
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -157,12 +142,6 @@ public abstract class MessageBase extends BaseObservable  {
                         return topic;
                 }
         }
-
-        @JsonIgnore
-        public boolean isDelivered() {
-                return delivered;
-        }
-
 
         @JsonIgnore
         public void setModeId(int modeId) {

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageBase.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageBase.java
@@ -1,17 +1,18 @@
 package org.owntracks.android.messages;
-import androidx.databinding.BaseObservable;
 import androidx.annotation.NonNull;
-
-import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-
-import java.lang.ref.WeakReference;
+import androidx.databinding.BaseObservable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.owntracks.android.support.Preferences;
+import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
+import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
+
+import java.lang.ref.WeakReference;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type", defaultImpl = MessageUnknown.class)
 
@@ -28,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value=MessageLwt.class, name=MessageLwt.TYPE),
 })
 @JsonPropertyOrder(alphabetic=true)
-public abstract class MessageBase extends BaseObservable implements Runnable {
+public abstract class MessageBase extends BaseObservable  {
         static final String TYPE = "base";
 
         @JsonIgnore
@@ -103,30 +104,20 @@ public abstract class MessageBase extends BaseObservable implements Runnable {
                 this._topic_base = getBaseTopic(topic); // Normalized topic for all message types
         }
 
-        @Override
-        public void run(){
-                if(_processorIn != null && _processorIn.get() !=  null)
-                        processIncomingMessage(_processorIn.get());
-                if(_processorOut != null && _processorOut.get() !=  null) {
-                        processOutgoingMessage(_processorOut.get());
-                }
-        }
+//        @Override
+//        public void run(){
+//                if(_processorIn != null && _processorIn.get() !=  null)
+//                        processIncomingMessage(_processorIn.get());
+//                if(_processorOut != null && _processorOut.get() !=  null) {
+//                        processOutgoingMessage(_processorOut.get());
+//                }
+//        }
 
 
         @JsonIgnore
         public void setIncomingProcessor(@NonNull IncomingMessageProcessor processor) {
                 this._processorOut = null;
                 this._processorIn = new WeakReference<>(processor);
-        }
-
-        @JsonIgnore
-        public void setOutgoingProcessor(@NonNull OutgoingMessageProcessor processor) {
-                this._processorIn = null;
-                this._processorOut = new WeakReference<>(processor);
-        }
-
-        public void clearOutgoingProcessor() {
-                this._processorOut = null;
         }
 
         @JsonIgnore
@@ -181,11 +172,6 @@ public abstract class MessageBase extends BaseObservable implements Runnable {
         }
 
         @JsonIgnore
-        public void setDelivered(boolean delivered) {
-                this.delivered = delivered;
-        }
-
-        @JsonIgnore
         public boolean isDelivered() {
                 return delivered;
         }
@@ -202,4 +188,12 @@ public abstract class MessageBase extends BaseObservable implements Runnable {
         }
 
 
+        @JsonIgnore
+        @Override
+        @NonNull
+        public String toString() {
+                return String.format("%s id=%s",this.getClass().getName(), this.getMessageId());
+        }
+
+        public abstract void addMqttPreferences(Preferences preferences);
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageBase.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageBase.java
@@ -104,16 +104,6 @@ public abstract class MessageBase extends BaseObservable  {
                 this._topic_base = getBaseTopic(topic); // Normalized topic for all message types
         }
 
-//        @Override
-//        public void run(){
-//                if(_processorIn != null && _processorIn.get() !=  null)
-//                        processIncomingMessage(_processorIn.get());
-//                if(_processorOut != null && _processorOut.get() !=  null) {
-//                        processOutgoingMessage(_processorOut.get());
-//                }
-//        }
-
-
         @JsonIgnore
         public void setIncomingProcessor(@NonNull IncomingMessageProcessor processor) {
                 this._processorOut = null;

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageCard.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageCard.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
@@ -55,15 +54,8 @@ public class MessageCard extends MessageBase{
 
     }
 
-
     @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
     }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
-    }
-
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageCard.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageCard.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
@@ -49,6 +50,11 @@ public class MessageCard extends MessageBase{
 
     public String getBaseTopicSuffix() {  return BASETOPIC_SUFFIX; }
 
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+
+    }
+
 
     @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
@@ -57,7 +63,7 @@ public class MessageCard extends MessageBase{
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageClear.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageClear.java
@@ -5,19 +5,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 public class MessageClear extends MessageBase {
     static final String TYPE = "clear";
 
     @Override
-    protected void processIncomingMessage(IncomingMessageProcessor handler) {
+    public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
-    }
-
-    @Override
-    protected void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageClear.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageClear.java
@@ -3,6 +3,7 @@ package org.owntracks.android.messages;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
@@ -16,7 +17,7 @@ public class MessageClear extends MessageBase {
 
     @Override
     protected void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
     @Override
@@ -24,5 +25,20 @@ public class MessageClear extends MessageBase {
     public String getBaseTopicSuffix() {
         return null;
     }
+
+    @JsonIgnore
+    private String infoTopic;
+
+    public String getInfoTopic() {
+        return infoTopic;
+    }
+
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+        setRetained(true);
+        setTopic(preferences.getPubTopicBase());
+        infoTopic = this._topic+ preferences.getPubTopicInfoPart();
+    }
+
 
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageCmd.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageCmd.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -93,11 +92,6 @@ public class MessageCmd extends MessageBase{
     @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
-    }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageCmd.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageCmd.java
@@ -8,14 +8,14 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -97,7 +97,7 @@ public class MessageCmd extends MessageBase{
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
     @Override
@@ -106,11 +106,14 @@ public class MessageCmd extends MessageBase{
     }
 
     @Override
+    public void addMqttPreferences(Preferences preferences) {
+        setTopic(preferences.getPubTopicCommands());
+    }
+
+    @Override
     @JsonIgnore
     public void setTopic(String topic) {
         // Full topic is needed instead of the normalized base topic to verify if the message arrived on the correct topic
         this._topic = topic;
     }
-
-
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageConfiguration.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageConfiguration.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.owntracks.android.support.MessageWaypointCollection;
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
 import java.util.Map;
 import java.util.Set;
@@ -73,16 +72,9 @@ public class MessageConfiguration extends MessageBase{
 
     @Override
     @JsonIgnore
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
-    }
-
-    @Override
-    @JsonIgnore
     public String getBaseTopicSuffix() {
         return null;
     }
-
 
     @JsonIgnore
     public Set<String> getKeys() {

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageConfiguration.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageConfiguration.java
@@ -4,18 +4,17 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.MessageWaypointCollection;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 import org.owntracks.android.support.Preferences;
+import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
+import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 public class MessageConfiguration extends MessageBase{
     static final String TYPE = "configuration";
@@ -57,6 +56,11 @@ public class MessageConfiguration extends MessageBase{
         set(Preferences.Keys.TRACKER_ID, tid);
     }
 
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+
+    }
+
     @JsonIgnore
     public Object get(String key) {
         return map.get(key);
@@ -70,7 +74,7 @@ public class MessageConfiguration extends MessageBase{
     @Override
     @JsonIgnore
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageEncrypted.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageEncrypted.java
@@ -2,11 +2,11 @@ package org.owntracks.android.messages;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -29,10 +29,15 @@ public class MessageEncrypted extends MessageBase{
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
     @Override
     public String getBaseTopicSuffix() {  return null; }
+
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+
+    }
 
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageEncrypted.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageEncrypted.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -25,11 +24,6 @@ public class MessageEncrypted extends MessageBase{
     @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
-    }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageEvent.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageEvent.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -24,10 +23,4 @@ public class MessageEvent extends MessageBase{
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
     }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
-    }
-
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageEvent.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageEvent.java
@@ -2,11 +2,11 @@ package org.owntracks.android.messages;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -14,6 +14,12 @@ public class MessageEvent extends MessageBase{
     static final String TYPE = "event";
     private static final String BASETOPIC_SUFFIX = "/event";
     public String getBaseTopicSuffix() {  return BASETOPIC_SUFFIX; }
+
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+        setTopic(preferences.getPubTopicEvents());
+    }
+
     @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
@@ -21,7 +27,7 @@ public class MessageEvent extends MessageBase{
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageLocation.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageLocation.java
@@ -12,7 +12,6 @@ import com.google.android.gms.maps.model.LatLng;
 import org.owntracks.android.model.FusedContact;
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -172,11 +171,6 @@ public class MessageLocation extends MessageBase {
     @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
-    }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
     }
 
     public void setTid(String tid) {

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageLocation.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageLocation.java
@@ -1,5 +1,7 @@
 package org.owntracks.android.messages;
 
+import androidx.annotation.NonNull;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -8,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.owntracks.android.model.FusedContact;
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
@@ -162,7 +165,7 @@ public class MessageLocation extends MessageBase {
     }
 
     @JsonIgnore
-    public LatLng getLatLng() {
+    private LatLng getLatLng() {
         return point != null ? point : (point = new LatLng(lat, lon));
     }
 
@@ -173,7 +176,7 @@ public class MessageLocation extends MessageBase {
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
     public void setTid(String tid) {
@@ -207,6 +210,21 @@ public class MessageLocation extends MessageBase {
 
     public int getVac() {
         return this.vac;
+    }
+
+    @JsonIgnore
+    @Override
+    @NonNull
+    public String toString() {
+        return String.format("%s: %s",super.toString(), this.getLatLng());
+    }
+
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+        setTopic(preferences.getPubTopicLocations());
+        setQos(preferences.getPubQosLocations());
+        setRetained(preferences.getPubRetainLocations());
+
     }
 }
 

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageLwt.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageLwt.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -24,10 +23,4 @@ public class MessageLwt extends MessageBase {
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
     }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
-    }
-
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageLwt.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageLwt.java
@@ -2,11 +2,11 @@ package org.owntracks.android.messages;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -16,13 +16,18 @@ public class MessageLwt extends MessageBase {
     public String getBaseTopicSuffix() {  return null; }
 
     @Override
+    public void addMqttPreferences(Preferences preferences) {
+
+    }
+
+    @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
     }
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageTransition.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageTransition.java
@@ -9,7 +9,6 @@ import com.google.android.gms.location.Geofence;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -131,12 +130,6 @@ public class MessageTransition extends MessageBase{
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
     }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
-    }
-
 
     public void setLat(double lat) {
         this.lat = lat;

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageTransition.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageTransition.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.android.gms.location.Geofence;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -55,6 +56,13 @@ public class MessageTransition extends MessageBase{
 
     public void setTid(String tid) {
         this.tid = tid;
+    }
+
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+        setTopic(preferences.getPubTopicEvents());
+        setQos(preferences.getPubQosEvents());
+        setRetained(preferences.getPubRetainEvents());
     }
 
     @JsonProperty("t")
@@ -126,7 +134,7 @@ public class MessageTransition extends MessageBase{
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
 

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageUnknown.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageUnknown.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -24,10 +23,4 @@ public class MessageUnknown extends MessageBase {
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
     }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
-    }
-
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageUnknown.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageUnknown.java
@@ -2,11 +2,11 @@ package org.owntracks.android.messages;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -16,13 +16,18 @@ public class MessageUnknown extends MessageBase {
     public String getBaseTopicSuffix() {  return null; }
 
     @Override
+    public void addMqttPreferences(Preferences preferences) {
+
+    }
+
+    @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
     }
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageWaypoint.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageWaypoint.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -68,11 +67,6 @@ public class MessageWaypoint extends MessageBase{
     @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
-    }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageWaypoint.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageWaypoint.java
@@ -2,11 +2,11 @@ package org.owntracks.android.messages;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -72,12 +72,19 @@ public class MessageWaypoint extends MessageBase{
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
     @Override
     public boolean isValidMessage() {
         return super.isValidMessage() && (desc != null);
+    }
+
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+        setTopic(preferences.getPubTopicWaypoints());
+        setQos(preferences.getPubQosWaypoints());
+        setRetained(preferences.getPubRetainWaypoints());
     }
 
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageWaypoints.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageWaypoints.java
@@ -2,12 +2,12 @@ package org.owntracks.android.messages;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-
-import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.MessageWaypointCollection;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
-
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.owntracks.android.support.MessageWaypointCollection;
+import org.owntracks.android.support.Preferences;
+import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
+import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -31,10 +31,17 @@ public class MessageWaypoints extends MessageBase{
 
     @Override
     public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-        handler.processOutgoingMessage(this);
+//        handler.processOutgoingMessage(this);
     }
 
     @Override
     public String getBaseTopicSuffix() {  return null; }
+
+    @Override
+    public void addMqttPreferences(Preferences preferences) {
+        setTopic(preferences.getPubTopicWaypoints());
+        setQos(preferences.getPubQosWaypoints());
+        setRetained(preferences.getPubRetainWaypoints());
+    }
 
 }

--- a/project/app/src/main/java/org/owntracks/android/messages/MessageWaypoints.java
+++ b/project/app/src/main/java/org/owntracks/android/messages/MessageWaypoints.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.owntracks.android.support.MessageWaypointCollection;
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
-import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "_type")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -27,11 +26,6 @@ public class MessageWaypoints extends MessageBase{
     @Override
     public void processIncomingMessage(IncomingMessageProcessor handler) {
         handler.processIncomingMessage(this);
-    }
-
-    @Override
-    public void processOutgoingMessage(OutgoingMessageProcessor handler) {
-//        handler.processOutgoingMessage(this);
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
@@ -40,7 +40,6 @@ import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.Tasks;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -64,7 +63,6 @@ import org.owntracks.android.ui.map.MapActivity;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
@@ -580,11 +578,7 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
                 break;
         }
         Timber.d("Location update request params: mode %s, interval (s):%s, fastestInterval (s):%s, priority:%s, displacement (m):%s", monitoring, TimeUnit.MILLISECONDS.toSeconds(request.getInterval()), TimeUnit.MILLISECONDS.toSeconds(request.getFastestInterval()), request.getPriority(), request.getSmallestDisplacement());
-        try {
-            Tasks.await(fusedLocationClient.flushLocations());
-        } catch (ExecutionException | InterruptedException e) {
-            Timber.e(e, "Interrupted flushing locations");
-        }
+        fusedLocationClient.flushLocations();
         fusedLocationClient.requestLocationUpdates(request, locationCallback, runner.getBackgroundHandler().getLooper())
                 .addOnSuccessListener(_void -> Timber.d("Location update request success"))
                 .addOnFailureListener(throwable -> Timber.e(throwable, "Location update request failure"))

--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
@@ -144,7 +144,7 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
     @Override
     public void onCreate() {
         super.onCreate();
-        Timber.v("Background service onCreate. ThreadID: %s", Thread.currentThread().getId());
+        Timber.v("Background service onCreate. ThreadID: %s", Thread.currentThread());
         serviceBridge.bind(this);
         mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
         mGeofencingClient = LocationServices.getGeofencingClient(this);
@@ -520,6 +520,8 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
 
         if (location.getTime() > locationRepo.getCurrentLocationTime()) {
             locationProcessor.onLocationChanged(location,reportType);
+        } else {
+            Timber.tag("outgoing").v("Not re-sending message with same timestamp as last");
         }
     }
 

--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
@@ -170,7 +170,9 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
         startForeground(NOTIFICATION_ID_ONGOING, getOngoingNotification());
 
         setupLocationRequest();
-        setupLocationPing();
+
+        scheduler.scheduleLocationPing();
+
 
         setupGeofences();
 
@@ -485,10 +487,6 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
     private void clearEventStackNotification() {
         Timber.v("clearing notification stack");
         activeNotifications.clear();
-    }
-    // TODO: Move to somewere else
-    private void setupLocationPing() {
-        scheduler.scheduleLocationPing();
     }
 
     private void onGeofencingEvent(@Nullable final GeofencingEvent event) {

--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
@@ -703,8 +703,8 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     public void onEvent(MessageLocation m) {
-        Timber.v("MessageLocation received %s, %s, outgoing: %s, delivered: %s ", m, lastLocationMessage, m.isOutgoing(), m.isDelivered());
-        if (m.isDelivered() && (lastLocationMessage == null || lastLocationMessage.getTst() <= m.getTst())) {
+        Timber.v("MessageLocation received %s, %s, outgoing: %s", m, lastLocationMessage, !m.isIncoming());
+        if (lastLocationMessage == null || lastLocationMessage.getTst() <= m.getTst()) {
             this.lastLocationMessage = m;
             updateOngoingNotification();
             geocodingProvider.resolve(m, this);

--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
@@ -375,7 +375,7 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
                 return getString(R.string.monitoring_quiet);
             case LocationProcessor.MONITORING_MANUAL:
                 return getString(R.string.monitoring_manual);
-            case LocationProcessor.MONITORING_SIGNIFFICANT:
+            case LocationProcessor.MONITORING_SIGNIFICANT:
                 return getString(R.string.monitoring_signifficant);
             case LocationProcessor.MONITORING_MOVE:
                 return getString(R.string.monitoring_move);
@@ -563,7 +563,7 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
                 request.setSmallestDisplacement(preferences.getLocatorDisplacement());
                 request.setPriority(LocationRequest.PRIORITY_LOW_POWER);
                 break;
-            case LocationProcessor.MONITORING_SIGNIFFICANT:
+            case LocationProcessor.MONITORING_SIGNIFICANT:
                 request.setInterval(TimeUnit.SECONDS.toMillis(preferences.getLocatorInterval()));
                 request.setSmallestDisplacement(preferences.getLocatorDisplacement());
                 request.setPriority(getLocationRequestPriority());

--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
@@ -144,6 +144,7 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
     @Override
     public void onCreate() {
         super.onCreate();
+        Timber.v("Background service onCreate. ThreadID: %s", Thread.currentThread().getId());
         serviceBridge.bind(this);
         mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
         mGeofencingClient = LocationServices.getGeofencingClient(this);
@@ -172,7 +173,6 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
         setupLocationRequest();
 
         scheduler.scheduleLocationPing();
-
 
         setupGeofences();
 
@@ -516,7 +516,7 @@ public class BackgroundService extends DaggerService implements OnCompleteListen
             Timber.e("no location provided");
             return;
         }
-        Timber.v("location update received: tst:%s, acc:%s, lat:%s, lon:%s type:%s",location.getTime(), location.getAccuracy(), location.getLatitude(), location.getLongitude(), reportType);
+        Timber.tag("outgoing").v("location update received: tst:%s, acc:%s, lat:%s, lon:%s type:%s", location.getTime(), location.getAccuracy(), location.getLatitude(), location.getLongitude(), reportType);
 
         if (location.getTime() > locationRepo.getCurrentLocationTime()) {
             locationProcessor.onLocationChanged(location,reportType);

--- a/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
@@ -60,7 +60,7 @@ public class LocationProcessor {
     }
 
     public void publishLocationMessage(@Nullable String trigger) {
-        Timber.v("trigger:%s", trigger);
+        Timber.v("trigger: %s. ThreadID: %s", trigger, Thread.currentThread().getId());
         if (!locationRepo.hasLocation()) {
             Timber.e("no location available");
             return;
@@ -166,7 +166,7 @@ public class LocationProcessor {
         }
     }
 
-    public void publishWaypointMessage(@NonNull WaypointModel e) {
+    void publishWaypointMessage(@NonNull WaypointModel e) {
         messageProcessor.queueMessageForSending(waypointsRepo.fromDaoObject(e));
     }
 
@@ -200,6 +200,4 @@ public class LocationProcessor {
         message.setWaypoints(collection);
         messageProcessor.queueMessageForSending(message);
     }
-
-
 }

--- a/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
@@ -39,7 +39,7 @@ public class LocationProcessor {
 
     public static final int MONITORING_QUIET = -1;
     public static final int MONITORING_MANUAL = 0;
-    public static final int MONITORING_SIGNIFFICANT = 1;
+    public static final int MONITORING_SIGNIFICANT = 1;
     public static final int MONITORING_MOVE = 2;
 
 

--- a/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
@@ -114,7 +114,7 @@ public class LocationProcessor {
             message.setConn(deviceMetricsProvider.getConnectionType());
         }
 
-        messageProcessor.sendMessage(message);
+        messageProcessor.queueMessageForSending(message);
     }
 
     //TODO: refactor to use ObjectBox query directly
@@ -128,14 +128,13 @@ public class LocationProcessor {
         return l;
     }
 
-    public void onLocationChanged(@NonNull Location l, @Nullable String reportType) {
+    void onLocationChanged(@NonNull Location l, @Nullable String reportType) {
         locationRepo.setCurrentLocation(l);
-
         publishLocationMessage(reportType);
     }
 
 
-    public void onWaypointTransition(@NonNull WaypointModel w, @NonNull final Location l, final int transition, @NonNull final String trigger) {
+    void onWaypointTransition(@NonNull WaypointModel w, @NonNull final Location l, final int transition, @NonNull final String trigger) {
         Timber.v("geofence %s/%s transition:%s, trigger:%s", w.getTst(), w.getDescription(), transition == Geofence.GEOFENCE_TRANSITION_ENTER ? "enter" : "exit", trigger);
 
         if (ignoreLowAccuracy(l)) {
@@ -168,7 +167,7 @@ public class LocationProcessor {
     }
 
     public void publishWaypointMessage(@NonNull WaypointModel e) {
-        messageProcessor.sendMessage(waypointsRepo.fromDaoObject(e));
+        messageProcessor.queueMessageForSending(waypointsRepo.fromDaoObject(e));
     }
 
     private void publishTransitionMessage(@NonNull WaypointModel w, @NonNull Location triggeringLocation, int transition, String trigger) {
@@ -182,7 +181,7 @@ public class LocationProcessor {
         message.setTst(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));
         message.setWtst(w.getTst());
         message.setDesc(w.getDescription());
-        messageProcessor.sendMessage(message);
+        messageProcessor.queueMessageForSending(message);
     }
 
 
@@ -199,7 +198,7 @@ public class LocationProcessor {
             collection.add(m);
         }
         message.setWaypoints(collection);
-        messageProcessor.sendMessage(message);
+        messageProcessor.queueMessageForSending(message);
     }
 
 

--- a/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.java
@@ -2,6 +2,7 @@ package org.owntracks.android.services;
 
 import android.location.Location;
 import android.os.Build;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -29,20 +30,16 @@ import timber.log.Timber;
 
 @PerApplication
 public class LocationProcessor {
-
     private final MessageProcessor messageProcessor;
     private final Preferences preferences;
     private final LocationRepo locationRepo;
     private final WaypointsRepo waypointsRepo;
     private final DeviceMetricsProvider deviceMetricsProvider;
 
-
     public static final int MONITORING_QUIET = -1;
     public static final int MONITORING_MANUAL = 0;
     public static final int MONITORING_SIGNIFICANT = 1;
     public static final int MONITORING_MOVE = 2;
-
-
 
     @Inject
     public LocationProcessor(MessageProcessor messageProcessor, Preferences preferences, LocationRepo locationRepo, WaypointsRepo waypointsRepo, DeviceMetricsProvider deviceMetricsProvider) {
@@ -60,7 +57,7 @@ public class LocationProcessor {
     }
 
     public void publishLocationMessage(@Nullable String trigger) {
-        Timber.v("trigger: %s. ThreadID: %s", trigger, Thread.currentThread().getId());
+        Timber.v("trigger: %s. ThreadID: %s", trigger, Thread.currentThread());
         if (!locationRepo.hasLocation()) {
             Timber.e("no location available");
             return;

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
@@ -22,6 +22,7 @@ import org.owntracks.android.support.Events;
 import org.owntracks.android.support.Parser;
 import org.owntracks.android.support.Preferences;
 import org.owntracks.android.support.ServiceBridge;
+import org.owntracks.android.support.interfaces.ConfigurationIncompleteException;
 import org.owntracks.android.support.interfaces.IncomingMessageProcessor;
 import org.owntracks.android.support.interfaces.StatefulServiceMessageProcessor;
 
@@ -83,7 +84,15 @@ public class MessageProcessor implements IncomingMessageProcessor {
     }
 
     public boolean isEndpointConfigurationComplete() {
-        return this.endpoint != null && this.endpoint.isConfigurationComplete();
+        try {
+            if (this.endpoint != null) {
+                this.endpoint.checkConfigurationComplete();
+                return true;
+            }
+        } catch (ConfigurationIncompleteException e) {
+            return false;
+        }
+        return false;
     }
 
     public enum EndpointState {
@@ -103,7 +112,11 @@ public class MessageProcessor implements IncomingMessageProcessor {
 
         public String getMessage() {
             if (message == null) {
-                return error.getMessage();
+                if (error != null) {
+                    return error.getMessage();
+                } else {
+                    return null;
+                }
             }
             return message;
         }

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
@@ -3,6 +3,7 @@ package org.owntracks.android.services;
 import android.content.Context;
 import android.content.res.Resources;
 
+import org.eclipse.paho.client.mqttv3.MqttException;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -113,7 +114,10 @@ public class MessageProcessor implements IncomingMessageProcessor {
         public String getMessage() {
             if (message == null) {
                 if (error != null) {
-                    return error.toString();
+                    if (error instanceof MqttException && error.getCause() != null)
+                        return String.format("MQTT Error: %s", error.getCause().getMessage());
+                    else
+                        return error.getMessage();
                 } else {
                     return null;
                 }

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
@@ -99,16 +99,19 @@ public class MessageProcessor implements IncomingMessageProcessor {
         ERROR_CONFIGURATION;
 
         String message;
-        private Exception error;
+        private Throwable error;
 
         public String getMessage() {
+            if (message == null) {
+                return error.getMessage();
+            }
             return message;
         }
 
-        public Exception getError() {
+        public Throwable getError() {
             return error;
         }
-        public EndpointState setMessage(String message) {
+        public EndpointState withMessage(String message) {
             this.message = message;
             return this;
         }
@@ -123,7 +126,7 @@ public class MessageProcessor implements IncomingMessageProcessor {
             return (name());
         }
 
-        public EndpointState setError(Exception error) {
+        public EndpointState withError(Throwable error) {
             this.error = error;
             return this;
         }

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
@@ -167,7 +167,7 @@ public class MessageProcessor implements IncomingMessageProcessor {
     }
 
     private void loadOutgoingMessageProcessor(){
-        Timber.v("Reloading outgoing message processor");
+        Timber.tag("outgoing").v("Reloading outgoing message processor. ThreadID: %s", Thread.currentThread().getId());
         if(outgoingMessageProcessorExecutor != null) {
             outgoingMessageProcessorExecutor.purge();
         }
@@ -178,7 +178,6 @@ public class MessageProcessor implements IncomingMessageProcessor {
 
         eventBus.postSticky(queueEvent.withNewLength(outgoingQueue.size()));
 
-        Timber.v("instantiating new outgoingMessageProcessorExecutor");
         switch (preferences.getModeId()) {
             case MessageProcessorEndpointHttp.MODE_ID:
                 this.endpoint = new MessageProcessorEndpointHttp(this, this.parser, this.preferences, this.scheduler, this.eventBus, outgoingQueue);
@@ -211,7 +210,7 @@ public class MessageProcessor implements IncomingMessageProcessor {
 
     public void queueMessageForSending(MessageBase message) {
         if(!acceptMessages) return;
-        Timber.v("Queueing messageId:%s, queueLength:%s, queue:%s", message.getMessageId(), outgoingQueue.size(), outgoingQueue);
+        Timber.tag("outgoing").v("Queueing messageId:%s, queueLength:%s, queue:%s, ThreadID: %s", message.getMessageId(), outgoingQueue.size(), outgoingQueue, Thread.currentThread().getId());
         synchronized (outgoingQueue) {
             if (!outgoingQueue.offer(message)) {
                 MessageBase droppedMessage = outgoingQueue.poll();
@@ -224,7 +223,7 @@ public class MessageProcessor implements IncomingMessageProcessor {
     }
 
      void onMessageDelivered(Long messageId) {
-        Timber.v("onMessageDelivered in MessageProcessor Noop");
+        Timber.tag("outgoing").v("onMessageDelivered in MessageProcessor Noop. ThreadID: %s", Thread.currentThread().getId());
         eventBus.postSticky(queueEvent.withNewLength(outgoingQueue.size()));
 //        MessageBase m = outgoingQueue.get(messageId);
 //        if(m != null) {
@@ -263,7 +262,6 @@ public class MessageProcessor implements IncomingMessageProcessor {
 
     void onMessageDeliveryFailedFinal(Long messageId) {
         Timber.e(":%s", messageId);
-//        dequeue(messageId);
         eventBus.postSticky(queueEvent.withNewLength(outgoingQueue.size()));
     }
 

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
@@ -224,9 +224,10 @@ public class MessageProcessor implements IncomingMessageProcessor {
         }
     }
 
-     void onMessageDelivered(Long messageId) {
+     void onMessageDelivered(MessageBase messageBase) {
         Timber.tag("outgoing").d("onMessageDelivered in MessageProcessor Noop. ThreadID: %s", Thread.currentThread());
         eventBus.postSticky(queueEvent.withNewLength(outgoingQueue.size()));
+        eventBus.post(messageBase);
     }
 
     void onMessageDeliveryFailedFinal(Long messageId) {

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpoint.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpoint.java
@@ -22,6 +22,7 @@ public abstract class MessageProcessorEndpoint implements OutgoingMessageProcess
     }
 
     void onMessageReceived(MessageBase message) {
+        message.setIncoming();
         message.setModeId(getModeId());
         onFinalizeMessage(message).processIncomingMessage(messageProcessor);
     }

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpoint.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpoint.java
@@ -17,4 +17,6 @@ public abstract class MessageProcessorEndpoint implements OutgoingMessageProcess
 
     protected abstract MessageBase onFinalizeMessage(MessageBase message);
     abstract int getModeId();
+
+    public abstract Runnable getBackgroundOutgoingRunnable();
 }

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpoint.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpoint.java
@@ -20,7 +20,7 @@ public abstract class MessageProcessorEndpoint implements OutgoingMessageProcess
 
     void onMessageReceived(MessageBase message) {
         message.setModeId(getModeId());
-        messageProcessor.onMessageReceived(onFinalizeMessage(message));
+        onFinalizeMessage(message).processIncomingMessage(messageProcessor);
     }
 
     protected abstract MessageBase onFinalizeMessage(MessageBase message);

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpoint.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpoint.java
@@ -1,10 +1,18 @@
 package org.owntracks.android.services;
 
 import org.owntracks.android.messages.MessageBase;
+import org.owntracks.android.support.interfaces.ConfigurationIncompleteException;
 import org.owntracks.android.support.interfaces.OutgoingMessageProcessor;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import timber.log.Timber;
 
 public abstract class MessageProcessorEndpoint implements OutgoingMessageProcessor {
     MessageProcessor messageProcessor;
+    BlockingDeque<MessageBase> outgoingMessageQueue;
 
     MessageProcessorEndpoint(MessageProcessor messageProcessor) {
         this.messageProcessor = messageProcessor;
@@ -16,7 +24,49 @@ public abstract class MessageProcessorEndpoint implements OutgoingMessageProcess
     }
 
     protected abstract MessageBase onFinalizeMessage(MessageBase message);
+
     abstract int getModeId();
 
-    public abstract Runnable getBackgroundOutgoingRunnable();
+    abstract void sendMessage(MessageBase m) throws ConfigurationIncompleteException, OutgoingMessageSendingException, IOException;
+
+    public Runnable getBackgroundOutgoingRunnable() {
+        return this::sendAvailableMessages;
+    }
+
+    private void sendAvailableMessages() {
+        Timber.tag("outgoing").v("Starting outbound message loop. ThreadID: %s", Thread.currentThread());
+        MessageBase lastFailedMessageToBeRetried = null;
+        while (true) {
+            try {
+                MessageBase message;
+                if (lastFailedMessageToBeRetried == null) {
+                    message = outgoingMessageQueue.take();
+                } else {
+                    message = lastFailedMessageToBeRetried;
+                }
+                try {
+                    sendMessage(message);
+                    lastFailedMessageToBeRetried = null;
+                } catch (OutgoingMessageSendingException | ConfigurationIncompleteException e) {
+                    Timber.tag("outgoing").w(("Error sending message. Re-queueing"));
+                    lastFailedMessageToBeRetried = message;
+                } catch (IOException e) {
+                    // Deserialization failure, drop and move on
+                }
+                if (lastFailedMessageToBeRetried != null) {
+                    Thread.sleep(TimeUnit.MINUTES.toMillis(1)); //TODO: better backoff algorithm
+                }
+            } catch (InterruptedException e) {
+                Timber.tag("outgoing").i(e, "Outgoing message loop interrupted");
+                break;
+            }
+        }
+        Timber.tag("outgoing").w("Exiting outgoingmessage loop");
+    }
+}
+
+class OutgoingMessageSendingException extends Throwable {
+    OutgoingMessageSendingException(Exception e) {
+        super(e);
+    }
 }

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
@@ -177,7 +177,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
             messageProcessor.onEndpointStateChanged(EndpointState.IDLE);
         } catch (IllegalArgumentException e) {
             httpEndpoint = null;
-            messageProcessor.onEndpointStateChanged(EndpointState.ERROR_CONFIGURATION.setError(e));
+            messageProcessor.onEndpointStateChanged(EndpointState.ERROR_CONFIGURATION.withError(e));
         }
     }
 
@@ -192,7 +192,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
         try {
             body = parser.toJson(message);
         } catch (IOException e) { // Message serialization failed. This shouldn't happen.
-            messageProcessor.onEndpointStateChanged(EndpointState.ERROR.setMessage(e.getMessage()));
+            messageProcessor.onEndpointStateChanged(EndpointState.ERROR.withMessage(e.getMessage()));
             return null;
         }
 
@@ -219,7 +219,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
             return request.build();
         } catch (Exception e) {
             Timber.e(e,"invalid header specified");
-            messageProcessor.onEndpointStateChanged(EndpointState.ERROR_CONFIGURATION.setMessage(e.getMessage()));
+            messageProcessor.onEndpointStateChanged(EndpointState.ERROR_CONFIGURATION.withMessage(e.getMessage()));
             httpEndpoint = null;
             return null;
         }
@@ -248,17 +248,17 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
                     try {
 
                         MessageBase[] result = parser.fromJson(r.body().byteStream());
-                        messageProcessor.onEndpointStateChanged(EndpointState.IDLE.setMessage("Response " + r.code() + ", " + result.length));
+                        messageProcessor.onEndpointStateChanged(EndpointState.IDLE.withMessage("Response " + r.code() + ", " + result.length));
 
                         for (MessageBase aResult : result) {
                             onMessageReceived(aResult);
                         }
                     } catch (JsonProcessingException e ) {
                         Timber.e("error:JsonParseException responseCode:%s", r.code());
-                        messageProcessor.onEndpointStateChanged(EndpointState.IDLE.setMessage("HTTP " +r.code() + ", JsonParseException"));
+                        messageProcessor.onEndpointStateChanged(EndpointState.IDLE.withMessage("HTTP " +r.code() + ", JsonParseException"));
                     } catch (Parser.EncryptionException e) {
                         Timber.e("error:JsonParseException responseCode:%s", r.code());
-                        messageProcessor.onEndpointStateChanged(EndpointState.ERROR.setMessage("HTTP: "+r.code() + ", EncryptionException"));
+                        messageProcessor.onEndpointStateChanged(EndpointState.ERROR.withMessage("HTTP: "+r.code() + ", EncryptionException"));
                     }
 
                 }
@@ -266,7 +266,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
             // Server could be contacted but returned non success HTTP code
             } else {
                 Timber.e("request was not successful. HTTP code %s", r.code());
-                messageProcessor.onEndpointStateChanged(EndpointState.ERROR.setMessage("HTTP code "+r.code() ));
+                messageProcessor.onEndpointStateChanged(EndpointState.ERROR.withMessage("HTTP code "+r.code() ));
                 messageProcessor.onMessageDeliveryFailed(messageId);
                 r.close();
                 return;
@@ -274,7 +274,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
         // Message was not send
         } catch (Exception e) {
             Timber.e(e,"error:IOException. Delivery failed ");
-            messageProcessor.onEndpointStateChanged(EndpointState.ERROR.setError(e));
+            messageProcessor.onEndpointStateChanged(EndpointState.ERROR.withError(e));
             messageProcessor.onMessageDeliveryFailed(messageId);
 
 

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
@@ -282,7 +282,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
             messageProcessor.onMessageDeliveryFailed(messageId);
             return;
         }
-        messageProcessor.onMessageDelivered(messageId);
+        messageProcessor.onMessageDelivered(message);
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
@@ -234,7 +234,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
         return str != null && str.length() > 0;
     }
 
-    private void sendMessage(MessageBase message) {
+    void sendMessage(MessageBase message) {
         long messageId = message.getMessageId();
         Request request = getRequest(message);
         if(request == null) {
@@ -280,8 +280,6 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
             Timber.e(e,"error:IOException. Delivery failed ");
             messageProcessor.onEndpointStateChanged(EndpointState.ERROR.withError(e));
             messageProcessor.onMessageDeliveryFailed(messageId);
-
-
             return;
         }
         messageProcessor.onMessageDelivered(messageId);

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
@@ -1,6 +1,7 @@
 package org.owntracks.android.services;
 
 import android.content.SharedPreferences;
+
 import androidx.annotation.Nullable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -9,13 +10,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.owntracks.android.App;
 import org.owntracks.android.BuildConfig;
 import org.owntracks.android.messages.MessageBase;
-import org.owntracks.android.messages.MessageClear;
-import org.owntracks.android.messages.MessageCmd;
-import org.owntracks.android.messages.MessageEvent;
-import org.owntracks.android.messages.MessageLocation;
-import org.owntracks.android.messages.MessageTransition;
-import org.owntracks.android.messages.MessageWaypoint;
-import org.owntracks.android.messages.MessageWaypoints;
 import org.owntracks.android.services.MessageProcessor.EndpointState;
 import org.owntracks.android.services.worker.Scheduler;
 import org.owntracks.android.support.Parser;
@@ -25,6 +19,7 @@ import org.owntracks.android.support.SocketFactory;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.X509TrustManager;
@@ -71,7 +66,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
     private HttpUrl httpEndpoint;
 
 
-    public MessageProcessorEndpointHttp(MessageProcessor messageProcessor, Parser parser, Preferences preferences, Scheduler scheduler, EventBus eventBus) {
+    public MessageProcessorEndpointHttp(MessageProcessor messageProcessor, Parser parser, Preferences preferences, Scheduler scheduler, EventBus eventBus, LinkedBlockingDeque<MessageBase> outgoingQueue) {
         super(messageProcessor);
         this.parser = parser;
         this.preferences = preferences;
@@ -289,46 +284,6 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
     }
 
     @Override
-    public void processOutgoingMessage(MessageBase message) {
-        sendMessage(message);
-    }
-
-    @Override
-    public void processOutgoingMessage(MessageCmd message) {
-        sendMessage(message);
-    }
-
-    @Override
-    public void processOutgoingMessage(MessageEvent message) {
-        sendMessage(message);
-    }
-
-    @Override
-    public void processOutgoingMessage(MessageLocation message) {
-        sendMessage(message);
-    }
-
-    @Override
-    public void processOutgoingMessage(MessageTransition message) {
-        sendMessage(message);
-    }
-
-    @Override
-    public void processOutgoingMessage(MessageWaypoint message) {
-        sendMessage(message);
-    }
-
-    @Override
-    public void processOutgoingMessage(MessageWaypoints message) {
-        sendMessage(message);
-    }
-
-    @Override
-    public void processOutgoingMessage(MessageClear message) {
-        sendMessage(message);
-    }
-
-    @Override
     public void onDestroy() {
         scheduler.cancelHttpTasks();
         preferences.unregisterOnPreferenceChangedListener(this);
@@ -356,6 +311,11 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
     @Override
     int getModeId() {
         return MODE_ID;
+    }
+
+    @Override
+    public Runnable getBackgroundOutgoingRunnable() {
+        return null;
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointHttp.java
@@ -20,7 +20,7 @@ import org.owntracks.android.support.interfaces.ConfigurationIncompleteException
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.concurrent.LinkedBlockingDeque;
+import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.X509TrustManager;
@@ -67,7 +67,7 @@ public class MessageProcessorEndpointHttp extends MessageProcessorEndpoint imple
     private HttpUrl httpEndpoint;
 
 
-    public MessageProcessorEndpointHttp(MessageProcessor messageProcessor, Parser parser, Preferences preferences, Scheduler scheduler, EventBus eventBus, LinkedBlockingDeque<MessageBase> outgoingQueue) {
+    public MessageProcessorEndpointHttp(MessageProcessor messageProcessor, Parser parser, Preferences preferences, Scheduler scheduler, EventBus eventBus, Queue<MessageBase> outgoingQueue) {
         super(messageProcessor);
         this.parser = parser;
         this.preferences = preferences;

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointMqtt.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointMqtt.java
@@ -103,7 +103,7 @@ public class MessageProcessorEndpointMqtt extends MessageProcessorEndpoint imple
             IMqttDeliveryToken pubToken = this.mqttClient.publish(m.getTopic(), parser.toJsonBytes(m), m.getQos(), m.getRetained());
             pubToken.waitForCompletion(TimeUnit.SECONDS.toMillis(30));
             Timber.d("message sent: %s", messageId);
-            messageProcessor.onMessageDelivered(messageId);
+            messageProcessor.onMessageDelivered(m);
         } catch (MqttException e) {
             Timber.e(e,"MQTT Exception delivering message");
             messageProcessor.onMessageDeliveryFailed(messageId);

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointMqtt.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessorEndpointMqtt.java
@@ -554,7 +554,7 @@ public class MessageProcessorEndpointMqtt extends MessageProcessorEndpoint imple
     }
 
     private void sendAvailableMessages() {
-        Timber.v("Starting outbound message loop");
+        Timber.tag("outgoing").v("Starting outbound message loop. ThreadID: %s", Thread.currentThread().getId());
         MessageBase lastFailedMessageToBeRetried = null;
         while (true) {
             try {
@@ -562,12 +562,12 @@ public class MessageProcessorEndpointMqtt extends MessageProcessorEndpoint imple
                 if (lastFailedMessageToBeRetried == null) {
                     message = outgoingQueue.take();
                 } else {
-                    message = lastFailedMessageToBeRetried
+                    message = lastFailedMessageToBeRetried;
                 }
                 try {
                     sendMessage(message);
                 } catch (MqttException | MqttConnectionException | ConfigurationIncompleteException e) {
-                    Timber.w(("Error sending message. Re-queueing"));
+                    Timber.tag("outgoing").w(("Error sending message. Re-queueing"));
                     lastFailedMessageToBeRetried = message;
                 } catch (IOException e) {
                     // Deserialization failure, drop and move on
@@ -576,11 +576,11 @@ public class MessageProcessorEndpointMqtt extends MessageProcessorEndpoint imple
                     Thread.sleep(15000);
                 }
             } catch (InterruptedException e) {
-                Timber.i(e, "Outgoing message loop interrupted");
+                Timber.tag("outgoing").i(e, "Outgoing message loop interrupted");
                 break;
             }
         }
-        Timber.w("Exiting outgoingmessage loop");
+        Timber.tag("outgoing").w("Exiting outgoingmessage loop");
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/services/worker/MQTTKeepaliveWorker.java
+++ b/project/app/src/main/java/org/owntracks/android/services/worker/MQTTKeepaliveWorker.java
@@ -27,7 +27,7 @@ public class MQTTKeepaliveWorker extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        Timber.v("MQTTKeepaliveWorker doing work");
+        Timber.tag("outgoing").v("MQTTKeepaliveWorker doing work. ThreadID: %s", Thread.currentThread().getId());
         return messageProcessor.statefulSendKeepalive() ? Result.success() : Result.retry();
     }
 }

--- a/project/app/src/main/java/org/owntracks/android/services/worker/MQTTKeepaliveWorker.java
+++ b/project/app/src/main/java/org/owntracks/android/services/worker/MQTTKeepaliveWorker.java
@@ -27,7 +27,7 @@ public class MQTTKeepaliveWorker extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        Timber.tag("outgoing").v("MQTTKeepaliveWorker doing work. ThreadID: %s", Thread.currentThread().getId());
+        Timber.tag("outgoing").v("MQTTKeepaliveWorker doing work. ThreadID: %s", Thread.currentThread());
         return messageProcessor.statefulSendKeepalive() ? Result.success() : Result.retry();
     }
 }

--- a/project/app/src/main/java/org/owntracks/android/services/worker/MQTTReconnectWorker.java
+++ b/project/app/src/main/java/org/owntracks/android/services/worker/MQTTReconnectWorker.java
@@ -26,7 +26,7 @@ public class MQTTReconnectWorker extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        Timber.tag("outgoing").i("MQTTReconnectWorker Doing work. ThreadID: %s", Thread.currentThread().getId());
+        Timber.tag("outgoing").i("MQTTReconnectWorker Doing work. ThreadID: %s", Thread.currentThread());
         if(!messageProcessor.isEndpointConfigurationComplete())
             return Result.failure();
         return messageProcessor.statefulCheckConnection() ? Result.success() : Result.retry();

--- a/project/app/src/main/java/org/owntracks/android/services/worker/MQTTReconnectWorker.java
+++ b/project/app/src/main/java/org/owntracks/android/services/worker/MQTTReconnectWorker.java
@@ -26,7 +26,7 @@ public class MQTTReconnectWorker extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        Timber.i("MQTTReconnectWorker Doing work (%s)",Thread.currentThread());
+        Timber.tag("outgoing").i("MQTTReconnectWorker Doing work. ThreadID: %s", Thread.currentThread().getId());
         if(!messageProcessor.isEndpointConfigurationComplete())
             return Result.failure();
         return messageProcessor.statefulCheckConnection() ? Result.success() : Result.retry();

--- a/project/app/src/main/java/org/owntracks/android/services/worker/Scheduler.java
+++ b/project/app/src/main/java/org/owntracks/android/services/worker/Scheduler.java
@@ -24,6 +24,7 @@ public class Scheduler {
     private static final String PERIODIC_TASK_SEND_LOCATION_PING = "PERIODIC_TASK_SEND_LOCATION_PING" ;
     private static final String PERIODIC_TASK_MQTT_KEEPALIVE = "PERIODIC_TASK_MQTT_KEEPALIVE" ;
     private static final String PERIODIC_TASK_MQTT_RECONNECT = "PERIODIC_TASK_MQTT_RECONNECT";
+    private static final String PERIODIC_TASK_PROCESS_OUTGOING_MESSAGES = "PERIODIC_TASK_PROCESS_OUTGOING_MESSAGES";
 
     private WorkManager workManager = WorkManager.getInstance();
 
@@ -53,7 +54,6 @@ public class Scheduler {
     }
 
     public void scheduleMqttPing(long keepAliveSeconds) {
-
         WorkRequest mqttPingWorkRequest = new PeriodicWorkRequest.Builder(MQTTKeepaliveWorker.class, keepAliveSeconds, TimeUnit.SECONDS)
                 .addTag(PERIODIC_TASK_MQTT_KEEPALIVE)
                 .setConstraints(anyNetworkConstraint)
@@ -93,6 +93,7 @@ public class Scheduler {
         workManager.cancelAllWorkByTag(PERIODIC_TASK_MQTT_RECONNECT);
         workManager.enqueue(mqttReconnectWorkRequest);
     }
+
 
     public void cancelMqttReconnect() {
         Timber.v("Cancelling task tag %s", PERIODIC_TASK_MQTT_RECONNECT);

--- a/project/app/src/main/java/org/owntracks/android/services/worker/SendLocationPingWorker.java
+++ b/project/app/src/main/java/org/owntracks/android/services/worker/SendLocationPingWorker.java
@@ -26,7 +26,7 @@ public class SendLocationPingWorker extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        Timber.tag("outgoing").v("SendLocationPingWorker doing work. ThreadID: %s", Thread.currentThread().getId());
+        Timber.tag("outgoing").v("SendLocationPingWorker doing work. ThreadID: %s", Thread.currentThread());
         locationProcessor.publishLocationMessage(MessageLocation.REPORT_TYPE_PING);
         return Result.success();
     }

--- a/project/app/src/main/java/org/owntracks/android/services/worker/SendLocationPingWorker.java
+++ b/project/app/src/main/java/org/owntracks/android/services/worker/SendLocationPingWorker.java
@@ -26,7 +26,7 @@ public class SendLocationPingWorker extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        Timber.v("SendLocationPingWorker doing work");
+        Timber.tag("outgoing").v("SendLocationPingWorker doing work. ThreadID: %s", Thread.currentThread().getId());
         locationProcessor.publishLocationMessage(MessageLocation.REPORT_TYPE_PING);
         return Result.success();
     }

--- a/project/app/src/main/java/org/owntracks/android/support/Preferences.java
+++ b/project/app/src/main/java/org/owntracks/android/support/Preferences.java
@@ -869,7 +869,7 @@ public class Preferences {
 
     public void setSetupCompleted() {
         sharedPreferences.edit().putBoolean(Keys._SETUP_NOT_COMPLETED , false).apply();
-
+        isFirstStart = false;
     }
 
     // Maybe make this configurable
@@ -938,7 +938,6 @@ public class Preferences {
 
     public boolean isObjectboxMigrated() {
         return isFirstStart || sharedPreferences.getBoolean(Keys._OBJECTBOX_MIGRATED, false);
-
     }
 
     public void setObjectBoxMigrated() {

--- a/project/app/src/main/java/org/owntracks/android/support/Preferences.java
+++ b/project/app/src/main/java/org/owntracks/android/support/Preferences.java
@@ -143,10 +143,6 @@ public class Preferences {
         }
     }
 
-    public boolean isFirstStart() {
-        return isFirstStart;
-    }
-
     public void checkFirstStart() {
         if(sharedPreferences.getBoolean(Keys._FIRST_START, true)) {
             Timber.v("Initial application launch");
@@ -862,7 +858,7 @@ public class Preferences {
         return getString(Keys._ENCRYPTION_KEY, R.string.valEmpty);
     }
 
-    boolean getSetupCompleted() {
+    public boolean isSetupCompleted() {
         // sharedPreferences because the value is independent from the selected mode
         return !sharedPreferences.getBoolean(Keys._SETUP_NOT_COMPLETED, false);
     }

--- a/project/app/src/main/java/org/owntracks/android/support/RequirementsChecker.java
+++ b/project/app/src/main/java/org/owntracks/android/support/RequirementsChecker.java
@@ -30,7 +30,7 @@ public class RequirementsChecker {
     }
 
     public boolean isInitialSetupCheckPassed() {
-        return preferences.getSetupCompleted();
+        return preferences.isSetupCompleted();
     }
 
 }

--- a/project/app/src/main/java/org/owntracks/android/support/interfaces/ConfigurationIncompleteException.java
+++ b/project/app/src/main/java/org/owntracks/android/support/interfaces/ConfigurationIncompleteException.java
@@ -1,0 +1,7 @@
+package org.owntracks.android.support.interfaces;
+
+public class ConfigurationIncompleteException extends Exception {
+    public ConfigurationIncompleteException(String message) {
+        super(message);
+    }
+}

--- a/project/app/src/main/java/org/owntracks/android/support/interfaces/OutgoingMessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/support/interfaces/OutgoingMessageProcessor.java
@@ -2,8 +2,6 @@ package org.owntracks.android.support.interfaces;
 
 
 public interface OutgoingMessageProcessor {
-
-
     void onCreateFromProcessor();
     void onDestroy();
 

--- a/project/app/src/main/java/org/owntracks/android/support/interfaces/OutgoingMessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/support/interfaces/OutgoingMessageProcessor.java
@@ -7,5 +7,6 @@ public interface OutgoingMessageProcessor {
     void onCreateFromProcessor();
     void onDestroy();
 
-    boolean isConfigurationComplete();
+    void checkConfigurationComplete() throws ConfigurationIncompleteException;
 }
+

--- a/project/app/src/main/java/org/owntracks/android/support/interfaces/OutgoingMessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/support/interfaces/OutgoingMessageProcessor.java
@@ -1,24 +1,8 @@
 package org.owntracks.android.support.interfaces;
 
 
-import org.owntracks.android.messages.MessageBase;
-import org.owntracks.android.messages.MessageClear;
-import org.owntracks.android.messages.MessageCmd;
-import org.owntracks.android.messages.MessageEvent;
-import org.owntracks.android.messages.MessageLocation;
-import org.owntracks.android.messages.MessageTransition;
-import org.owntracks.android.messages.MessageWaypoint;
-import org.owntracks.android.messages.MessageWaypoints;
-
 public interface OutgoingMessageProcessor {
-    void processOutgoingMessage(MessageBase message);
-    void processOutgoingMessage(MessageCmd message);
-    void processOutgoingMessage(MessageEvent message);
-    void processOutgoingMessage(MessageLocation message);
-    void processOutgoingMessage(MessageTransition message);
-    void processOutgoingMessage(MessageWaypoint message);
-    void processOutgoingMessage(MessageWaypoints message);
-    void processOutgoingMessage(MessageClear message);
+
 
     void onCreateFromProcessor();
     void onDestroy();

--- a/project/app/src/main/java/org/owntracks/android/support/interfaces/StatefulServiceMessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/support/interfaces/StatefulServiceMessageProcessor.java
@@ -4,4 +4,5 @@ package org.owntracks.android.support.interfaces;
 public interface StatefulServiceMessageProcessor {
     void reconnect();
     void disconnect();
+    boolean checkConnection();
 }

--- a/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.java
@@ -106,7 +106,7 @@ public class MapActivity extends BaseActivity<UiMapBinding, MapMvvm.ViewModel> i
         try {
             binding.mapView.onCreate(savedInstanceState);
         } catch (Exception e) {
-            Timber.e("not showing map due to issue   ");
+            Timber.e(e,"Failed to bind map to view.");
             isMapReady = false;
         }
         this.bottomSheetBehavior = BottomSheetBehavior.from(this.binding.bottomSheetLayout);

--- a/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.java
@@ -29,6 +29,7 @@ import androidx.lifecycle.Observer;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationCallback;
 import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
@@ -145,7 +146,7 @@ public class MapActivity extends BaseActivity<UiMapBinding, MapMvvm.ViewModel> i
         } else {
             startService((new Intent(this, BackgroundService.class)));
         }
-        fusedLocationClient = new FusedLocationProviderClient(this);
+        fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
     }
 
     private void checkAndRequestLocationPermissions() {
@@ -229,8 +230,7 @@ public class MapActivity extends BaseActivity<UiMapBinding, MapMvvm.ViewModel> i
         this.isMapReady = false;
 
         try {
-            if (binding.mapView != null)
-                binding.mapView.onResume();
+            binding.mapView.onResume();
 
             if (mMap == null) {
                 Timber.v("map not ready. Running initDelayed()");

--- a/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.java
@@ -329,7 +329,7 @@ public class MapActivity extends BaseActivity<UiMapBinding, MapMvvm.ViewModel> i
                 item.setIcon(R.drawable.ic_pause_white_36dp);
                 item.setTitle(R.string.monitoring_manual);
                 break;
-            case LocationProcessor.MONITORING_SIGNIFFICANT:
+            case LocationProcessor.MONITORING_SIGNIFICANT:
                 item.setIcon(R.drawable.ic_play_white_36dp);
                 item.setTitle(R.string.monitoring_signifficant);
 
@@ -369,7 +369,7 @@ public class MapActivity extends BaseActivity<UiMapBinding, MapMvvm.ViewModel> i
             Toast.makeText(this, R.string.monitoring_quiet, Toast.LENGTH_SHORT).show();
         }else if (newmode == LocationProcessor.MONITORING_MANUAL)  {
             Toast.makeText(this, R.string.monitoring_manual, Toast.LENGTH_SHORT).show();
-        } else if (newmode == LocationProcessor.MONITORING_SIGNIFFICANT)  {
+        } else if (newmode == LocationProcessor.MONITORING_SIGNIFICANT)  {
             Toast.makeText(this, R.string.monitoring_signifficant, Toast.LENGTH_SHORT).show();
         } else  {
             Toast.makeText(this, R.string.monitoring_move, Toast.LENGTH_SHORT).show();

--- a/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.java
@@ -92,7 +92,7 @@ public class MapActivity extends BaseActivity<UiMapBinding, MapMvvm.ViewModel> i
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (preferences.isFirstStart()) {
+        if (!preferences.isSetupCompleted()) {
             navigator.startActivity(WelcomeActivity.class);
             finish();
         }
@@ -163,6 +163,8 @@ public class MapActivity extends BaseActivity<UiMapBinding, MapMvvm.ViewModel> i
                 } else {
                     ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSIONS_REQUEST_CODE);
                 }
+            } else {
+                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSIONS_REQUEST_CODE);
             }
         }
     }

--- a/project/app/src/main/java/org/owntracks/android/ui/map/MapViewModel.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/map/MapViewModel.java
@@ -209,7 +209,7 @@ public class MapViewModel extends BaseViewModel<MapMvvm.View> implements MapMvvm
         MessageClear m = new MessageClear();
         if(activeContact != null) {
             m.setTopic(activeContact.getId());
-            messageProcessor.sendMessage(m);
+            messageProcessor.queueMessageForSending(m);
         }
     }
 

--- a/project/app/src/main/java/org/owntracks/android/ui/status/StatusViewModel.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/status/StatusViewModel.java
@@ -104,7 +104,7 @@ public class StatusViewModel extends BaseViewModel<StatusMvvm.View> implements S
 
     @Subscribe(sticky = true)
     public void onEvent(Events.QueueChanged e) {
-        Timber.e("queue changed %s", e.getNewLength());
+        Timber.v("queue changed %s", e.getNewLength());
         this.queueLength = e.getNewLength();
         notifyPropertyChanged(BR.endpointQueue);
     }

--- a/project/app/src/main/java/org/owntracks/android/ui/status/StatusViewModel.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/status/StatusViewModel.java
@@ -83,7 +83,7 @@ public class StatusViewModel extends BaseViewModel<StatusMvvm.View> implements S
     public void onEvent(MessageProcessor.EndpointState e) {
         this.endpointState = e;
         if(e.getError() != null)
-            this.endpointMessage = e.getError().toString();
+            this.endpointMessage = e.getMessage();
         else
             this.endpointMessage = e.getMessage();
         notifyPropertyChanged(BR.endpointState);

--- a/project/app/src/main/java/org/owntracks/android/ui/status/StatusViewModel.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/status/StatusViewModel.java
@@ -1,13 +1,14 @@
 package org.owntracks.android.ui.status;
 
 import android.content.Context;
-import androidx.databinding.Bindable;
 import android.location.Location;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.databinding.Bindable;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.owntracks.android.App;
@@ -70,7 +71,8 @@ public class StatusViewModel extends BaseViewModel<StatusMvvm.View> implements S
 
     @Override
     public boolean getDozeWhitelisted() {
-        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M || ((PowerManager) App.getContext().getSystemService(Context.POWER_SERVICE)).isIgnoringBatteryOptimizations(App.getContext().getPackageName());
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+                ((PowerManager) App.getContext().getSystemService(Context.POWER_SERVICE)).isIgnoringBatteryOptimizations(App.getContext().getPackageName());
     }
 
     @Override
@@ -82,10 +84,7 @@ public class StatusViewModel extends BaseViewModel<StatusMvvm.View> implements S
     @Subscribe(sticky = true)
     public void onEvent(MessageProcessor.EndpointState e) {
         this.endpointState = e;
-        if(e.getError() != null)
-            this.endpointMessage = e.getMessage();
-        else
-            this.endpointMessage = e.getMessage();
+        this.endpointMessage = e.getMessage();
         notifyPropertyChanged(BR.endpointState);
         notifyPropertyChanged(BR.endpointMessage);
     }

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/WelcomeFragmentMvvm.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/WelcomeFragmentMvvm.java
@@ -5,11 +5,8 @@ import org.owntracks.android.ui.base.viewmodel.MvvmViewModel;
 
 public interface WelcomeFragmentMvvm  {
 
-
     interface View extends MvvmView {
-        void onNextClicked();
         boolean isNextEnabled();
-
         void onShowFragment();
     }
 

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/WelcomeMvvm.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/WelcomeMvvm.java
@@ -7,13 +7,13 @@ import org.owntracks.android.ui.base.viewmodel.MvvmViewModel;
 
 public interface WelcomeMvvm {
 
+    // The view methods get called from all sorts of places. Fragments etc.
     interface View extends MvvmView {
         void showNextFragment();
         void setPagerIndicator(int position);
 
         // Called from Fragments to set button states
-        void setNextEnabled(boolean enabled);
-        void setDoneEnabled(boolean enabled);
+        void refreshNextDoneButtons();
     }
 
     interface ViewModel<V extends MvvmView> extends MvvmViewModel<V> {
@@ -25,6 +25,7 @@ public interface WelcomeMvvm {
         void onNextClicked();
         void onDoneClicked();
 
+        // Only really called from the Activity to make sure the view is up to date
         void setNextEnabled(boolean enabled);
         void setDoneEnabled(boolean enabled);
     }

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/WelcomeViewModel.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/WelcomeViewModel.java
@@ -49,8 +49,6 @@ public class WelcomeViewModel extends BaseViewModel<WelcomeMvvm.View> implements
         navigator.startActivity(MapActivity.class, null, Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
     }
 
-
-
     @Override
     public void setNextEnabled(boolean enabled) {
         this.nextEnabled = enabled;

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/finish/FinishFragment.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/finish/FinishFragment.java
@@ -1,11 +1,12 @@
 package org.owntracks.android.ui.welcome.finish;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.owntracks.android.R;
 import org.owntracks.android.databinding.UiWelcomeFinishBinding;
@@ -22,10 +23,6 @@ public class FinishFragment extends BaseSupportFragment<UiWelcomeFinishBinding, 
     }
 
     @Override
-    public void onNextClicked() {
-    }
-
-    @Override
     public boolean isNextEnabled() {
         return false;
     }
@@ -34,4 +31,5 @@ public class FinishFragment extends BaseSupportFragment<UiWelcomeFinishBinding, 
     public void onShowFragment() {
 
     }
+
 }

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/intro/IntroFragment.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/intro/IntroFragment.java
@@ -1,11 +1,12 @@
 package org.owntracks.android.ui.welcome.intro;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.owntracks.android.R;
 import org.owntracks.android.databinding.UiWelcomeIntroBinding;
@@ -21,16 +22,11 @@ public class IntroFragment extends BaseSupportFragment<UiWelcomeIntroBinding, No
     }
 
     @Override
-    public void onNextClicked() {
-    }
-
-    @Override
     public boolean isNextEnabled() {
         return true;
     }
 
     @Override
     public void onShowFragment() {
-
     }
 }

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/permission/PermissionFragmentMvvm.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/permission/PermissionFragmentMvvm.java
@@ -9,7 +9,6 @@ import org.owntracks.android.ui.welcome.WelcomeFragmentMvvm;
 public interface PermissionFragmentMvvm {
     interface View extends WelcomeFragmentMvvm.View {
         void requestFix();
-        void checkPermission();
     }
 
     interface ViewModel<V extends MvvmView> extends WelcomeFragmentMvvm.ViewModel<V> {

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/play/PlayFragment.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/play/PlayFragment.java
@@ -1,11 +1,10 @@
 package org.owntracks.android.ui.welcome.play;
 
-import android.app.Dialog;
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -13,74 +12,68 @@ import androidx.annotation.Nullable;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 
-import org.owntracks.android.App;
 import org.owntracks.android.R;
 import org.owntracks.android.databinding.UiWelcomePlayBinding;
 import org.owntracks.android.ui.base.BaseSupportFragment;
 import org.owntracks.android.ui.welcome.WelcomeMvvm;
 
 public class PlayFragment extends BaseSupportFragment<UiWelcomePlayBinding, PlayFragmentMvvm.ViewModel> implements PlayFragmentMvvm.View {
-    private static final int PLAY_SERVICES_RESOLUTION_REQUEST = 1;
+    public static final int PLAY_SERVICES_RESOLUTION_REQUEST = 1;
 
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+
         return setAndBindContentView(inflater, container, R.layout.ui_welcome_play, savedInstanceState);
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == PLAY_SERVICES_RESOLUTION_REQUEST) {
-            checkAvailability();
-        }
+    public void onPlayServicesResolutionResult() {
+        checkAvailability();
     }
 
     @Override
     public void requestFix() {
         GoogleApiAvailability googleAPI = GoogleApiAvailability.getInstance();
         int result = googleAPI.isGooglePlayServicesAvailable(getActivity());
-        Dialog d = googleAPI.getErrorDialog(getActivity(), result, PLAY_SERVICES_RESOLUTION_REQUEST);
-        if(d != null) {
-            d.show();
-        } else {
-            checkAvailability();
+        if (!googleAPI.showErrorDialogFragment(getActivity(), result, PLAY_SERVICES_RESOLUTION_REQUEST)) {
+            Toast.makeText(this.getContext(), "Unable to update Google Play Services", Toast.LENGTH_SHORT).show();
         }
+        checkAvailability();
     }
+
+    private boolean canProceed = false;
 
     private void checkAvailability() {
         GoogleApiAvailability googleAPI = GoogleApiAvailability.getInstance();
         int result = googleAPI.isGooglePlayServicesAvailable(getActivity());
-        switch(result) {
+        boolean fixAvailable = false;
+        String playServicesStatusMessage;
+        switch (result) {
             case ConnectionResult.SUCCESS:
-                ((WelcomeMvvm.View) getActivity()).setNextEnabled(true);
-                viewModel.setFixAvailable(false);
-                binding.message.setVisibility(View.VISIBLE);
-                binding.message.setText(getString(R.string.play_services_now_available));
+                canProceed = true;
+                playServicesStatusMessage = getString(R.string.play_services_now_available);
                 break;
             case ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED:
             case ConnectionResult.SERVICE_UPDATING:
-                ((WelcomeMvvm.View) getActivity()).setNextEnabled(false);
-                viewModel.setFixAvailable(true);
-                binding.message.setText(getString(R.string.play_services_update_required));
-                binding.message.setVisibility(View.VISIBLE);
-                viewModel.setFixAvailable(googleAPI.isUserResolvableError(result));
+                canProceed = false;
+                fixAvailable = true;
+                playServicesStatusMessage = getString(R.string.play_services_update_required);
+                break;
             default:
-                ((WelcomeMvvm.View) getActivity()).setNextEnabled(false);
-                viewModel.setFixAvailable(true);
-                binding.message.setText(getString(R.string.play_services_not_available));
-                binding.message.setVisibility(View.VISIBLE);
-                viewModel.setFixAvailable(googleAPI.isUserResolvableError(result));
+                canProceed = false;
+                fixAvailable = googleAPI.isUserResolvableError(result);
+                playServicesStatusMessage = getString(R.string.play_services_not_available);
+                break;
         }
-    }
-
-    @Override
-    public void onNextClicked() {
-
+        viewModel.setFixAvailable(fixAvailable);
+        viewModel.setMessage(playServicesStatusMessage);
+        ((WelcomeMvvm.View) getActivity()).refreshNextDoneButtons();
+        binding.invalidateAll();
     }
 
     @Override
     public boolean isNextEnabled() {
-        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(App.getContext()) == ConnectionResult.SUCCESS;
+        return canProceed;
     }
 
     @Override

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/play/PlayFragmentMvvm.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/play/PlayFragmentMvvm.java
@@ -5,7 +5,6 @@ import androidx.databinding.Bindable;
 import org.owntracks.android.ui.base.view.MvvmView;
 import org.owntracks.android.ui.welcome.WelcomeFragmentMvvm;
 
-
 public interface PlayFragmentMvvm {
     interface View extends WelcomeFragmentMvvm.View {
         void requestFix();
@@ -15,6 +14,9 @@ public interface PlayFragmentMvvm {
         void onFixClicked();
 
         @Bindable boolean isFixAvailable();
-        @Bindable void setFixAvailable(boolean enabled);
+        void setFixAvailable(boolean enabled);
+
+        @Bindable String getMessage();
+        void setMessage(String message);
     }
 }

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/play/PlayFragmentViewModel.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/play/PlayFragmentViewModel.java
@@ -1,9 +1,10 @@
 package org.owntracks.android.ui.welcome.play;
 
-import androidx.databinding.Bindable;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.databinding.Bindable;
 
 import org.owntracks.android.injection.scopes.PerFragment;
 import org.owntracks.android.ui.base.viewmodel.BaseViewModel;
@@ -14,8 +15,8 @@ import javax.inject.Inject;
 @PerFragment
 public class PlayFragmentViewModel extends BaseViewModel<PlayFragmentMvvm.View> implements PlayFragmentMvvm.ViewModel<PlayFragmentMvvm.View> {
 
-    private boolean playServicesAvailable;
     private boolean fixAvailable;
+    private String message;
 
     @Inject
     public PlayFragmentViewModel() {
@@ -43,5 +44,17 @@ public class PlayFragmentViewModel extends BaseViewModel<PlayFragmentMvvm.View> 
     @Bindable
     public void setFixAvailable(boolean available) {
         this.fixAvailable = available;
+    }
+
+    @Override
+    @Bindable
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    @Bindable
+    public void setMessage(String message) {
+         this.message = message;
     }
 }

--- a/project/app/src/main/java/org/owntracks/android/ui/welcome/version/VersionFragment.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/welcome/version/VersionFragment.java
@@ -4,12 +4,13 @@ import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.owntracks.android.R;
 import org.owntracks.android.databinding.UiWelcomeVersionBinding;
@@ -24,7 +25,6 @@ public class VersionFragment extends BaseSupportFragment<UiWelcomeVersionBinding
         View v = setAndBindContentView(inflater, container, R.layout.ui_welcome_version, savedInstanceState);
         binding.uiFragmentWelcomeVersionButtonLearnMore.setOnClickListener(this);
         return v;
-
     }
 
     @Override
@@ -35,11 +35,6 @@ public class VersionFragment extends BaseSupportFragment<UiWelcomeVersionBinding
         } catch (ActivityNotFoundException e) {
             Toast.makeText(getContext(), "No suitable browser installed", Toast.LENGTH_SHORT).show();
         }
-    }
-
-    @Override
-    public void onNextClicked() {
-
     }
 
     @Override

--- a/project/app/src/main/res/layout/ui_status.xml
+++ b/project/app/src/main/res/layout/ui_status.xml
@@ -68,6 +68,7 @@
                 android:layout_height="wrap_content"
                 android:text="@{vm.endpointMessage ?? @string/na, default=@string/na}"
                 android:ellipsize="none"
+                android:visibility="@{vm.endpointMessage!=null}"
                 style="@style/ListItemPrimary" />
 
             <TextView
@@ -78,6 +79,7 @@
                 android:text="Endpoint state message"
                 android:ellipsize="end"
                 android:paddingBottom="@dimen/activity_horizontal_margin"
+                android:visibility="@{vm.endpointMessage!=null}"
                 style="@style/ListItemSecondary" />
             <TextView
                 android:paddingLeft="@dimen/activity_horizontal_margin"

--- a/project/app/src/main/res/layout/ui_welcome.xml
+++ b/project/app/src/main/res/layout/ui_welcome.xml
@@ -1,92 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:app="http://schemas.android.com/apk/res-auto"
-	xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-	<data>
+    <data>
 
-		<import type="android.view.View"/>
+        <import type="android.view.View" />
 
-		<variable
-			name="vm"
-			type="org.owntracks.android.ui.welcome.WelcomeMvvm.ViewModel"/>
-	</data>
+        <variable
+            name="vm"
+            type="org.owntracks.android.ui.welcome.WelcomeMvvm.ViewModel" />
+    </data>
 
-	<androidx.constraintlayout.widget.ConstraintLayout
-		android:layout_width="match_parent"
-		android:layout_height="match_parent"
-		android:background="@color/primary"
-		tools:layout_editor_absoluteX="0dp"
-		tools:layout_editor_absoluteY="0dp">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/primary"
+        tools:layout_editor_absoluteX="0dp"
+        tools:layout_editor_absoluteY="0dp">
 
-		<ImageButton
-			android:id="@+id/btn_next"
-			android:layout_width="wrap_content"
-			android:layout_height="48dp"
-			android:layout_margin="0dp"
-			android:layout_marginBottom="0dp"
-			android:layout_marginRight="8dp"
-			android:background="?selectableItemBackgroundBorderless"
-			android:contentDescription="Next"
-			android:gravity="center"
-			android:onClick="@{() -> vm.onNextClicked()}"
-			android:paddingLeft="16dp"
-			android:paddingRight="16dp"
-			android:scaleType="fitCenter"
-			android:src="@drawable/ic_keyboard_arrow_right_white_24dp"
-			android:visibility="@{vm.nextEnabled ? View.VISIBLE : View.GONE}"
-			app:layout_constraintBottom_toBottomOf="parent"
-			app:layout_constraintRight_toRightOf="parent"/>
+        <ImageButton
+            android:id="@+id/btn_next"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:layout_margin="0dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:contentDescription="Next"
+            android:gravity="center"
+            android:onClick="@{() -> vm.onNextClicked()}"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_keyboard_arrow_right_white_24dp"
+            android:visibility="@{vm.nextEnabled}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintRight_toRightOf="parent" />
 
-		<ImageButton
-			android:id="@+id/done"
-			android:layout_width="wrap_content"
-			android:layout_height="48dp"
-			android:layout_margin="0dp"
-			android:layout_marginBottom="0dp"
-			android:layout_marginRight="8dp"
-			android:background="?selectableItemBackgroundBorderless"
-			android:contentDescription="Done"
-			android:gravity="center"
-			android:onClick="@{() -> vm.onDoneClicked()}"
-			android:paddingLeft="16dp"
-			android:paddingRight="16dp"
-			android:src="@drawable/ic_done_white_24dp"
-			android:textSize="18sp"
-			android:visibility="@{vm.doneEnabled}"
-			app:layout_constraintBottom_toBottomOf="parent"
-			app:layout_constraintRight_toRightOf="@+id/btn_next"/>
+        <ImageButton
+            android:id="@+id/done"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:layout_margin="0dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:contentDescription="Done"
+            android:gravity="center"
+            android:onClick="@{() -> vm.onDoneClicked()}"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:src="@drawable/ic_done_white_24dp"
+            android:textSize="18sp"
+            android:visibility="@{vm.doneEnabled}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintRight_toRightOf="@+id/btn_next" />
 
 
-		<org.owntracks.android.support.widgets.PausableViewPager
-			android:id="@+id/viewPager"
-			android:layout_width="0dp"
-			android:layout_height="0dp"
-			android:layout_marginBottom="8dp"
-			android:layout_marginLeft="8dp"
-			android:layout_marginRight="8dp"
-			android:layout_marginTop="8dp"
-			app:layout_constraintBottom_toTopOf="@+id/circles"
-			app:layout_constraintHorizontal_bias="0.0"
-			app:layout_constraintLeft_toLeftOf="parent"
-			app:layout_constraintRight_toRightOf="parent"
-			app:layout_constraintTop_toTopOf="parent"
-			app:layout_constraintVertical_bias="0.0"/>
+        <org.owntracks.android.support.widgets.PausableViewPager
+            android:id="@+id/viewPager"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintBottom_toTopOf="@+id/circles"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0" />
 
-		<LinearLayout
-			android:id="@+id/circles"
-			android:layout_width="wrap_content"
-			android:layout_height="48dp"
-			android:layout_marginBottom="0dp"
-			android:layout_marginLeft="8dp"
-			android:layout_marginRight="8dp"
-			android:gravity="center_vertical"
-			android:orientation="horizontal"
-			app:layout_constraintBottom_toBottomOf="parent"
+        <LinearLayout
+            android:id="@+id/circles"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginBottom="0dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
 
-			app:layout_constraintHorizontal_bias="0.5"
-			app:layout_constraintLeft_toLeftOf="parent"
-			app:layout_constraintRight_toRightOf="parent"/>
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent" />
 
-	</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/project/app/src/main/res/layout/ui_welcome_play.xml
+++ b/project/app/src/main/res/layout/ui_welcome_play.xml
@@ -1,90 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:tools="http://schemas.android.com/tools"
-	xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
     <data>
-        <variable name="vm" type="org.owntracks.android.ui.welcome.play.PlayFragmentMvvm.ViewModel" />
+
+        <variable
+            name="vm"
+            type="org.owntracks.android.ui.welcome.play.PlayFragmentMvvm.ViewModel" />
+
         <import type="android.view.View" />
     </data>
-    <RelativeLayout
 
+    <RelativeLayout
         android:id="@+id/welcome_fragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipChildren="false"
         android:background="@color/primary"
-        >
-
+        android:clipChildren="false">
 
         <ImageView
-            android:layout_marginTop="48dp"
-            android:layout_marginBottom="48dp"
-
             android:id="@+id/img"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:scaleType="centerInside"
-            android:src="@drawable/ic_assignment_late_white_48dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_alignParentTop="true"
 
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:contentDescription="@string/icon_description_warning" />
+            android:gravity="center_horizontal"
+            android:layout_marginTop="48dp"
+            android:layout_marginBottom="48dp"
+            android:contentDescription="@string/icon_description_warning"
+
+            android:scaleType="centerInside"
+            android:src="@drawable/ic_assignment_late_white_48dp" />
 
         <TextView
             android:id="@+id/screen_heading"
-            android:text="@string/welcome_play_heading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="24sp"
-            android:textColor="#ffffff"
-            android:paddingLeft="24dp"
-            android:paddingRight="24dp"
-            android:gravity="bottom|center_horizontal"
             android:layout_below="@+id/img"
             android:layout_marginBottom="8dp"
-            />
-
-
-		<TextView
-            android:id="@+id/screen_desc"
-            android:text="@string/welcome_play_description"
+            android:gravity="center_horizontal"
             android:paddingLeft="24dp"
             android:paddingRight="24dp"
-            android:layout_centerHorizontal="true"
+            android:text="@string/welcome_play_heading"
+            android:textColor="#ffffff"
+            android:textSize="24sp" />
+
+
+        <TextView
+            android:id="@+id/screen_desc"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:textSize="16sp"
-            android:textColor="#ffffff"
-            android:gravity="top|center_horizontal"
-            android:minHeight="@dimen/welcome_content_min_height"
             android:layout_below="@+id/screen_heading"
             android:layout_alignStart="@+id/screen_heading"
-            />
+            android:layout_centerHorizontal="true"
+            android:gravity="center_horizontal"
+            android:minHeight="@dimen/welcome_content_min_height"
+            android:paddingLeft="24dp"
+            android:paddingRight="24dp"
+            android:text="@string/welcome_play_description"
+            android:textColor="#ffffff"
+            android:textSize="16sp" />
 
 
-		<TextView
-			android:id="@+id/message"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_above="@+id/recover"
-			android:layout_centerHorizontal="true"
-			android:gravity="center_horizontal"
-			android:paddingLeft="24dp"
-			android:paddingRight="24dp"
-			android:text="@string/play_services_not_available"
-			android:textColor="#ffffff"
-			android:textSize="16sp"
-			android:visibility="visible"
-			tools:text="@string/play_services_not_available" />
-		<Button
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/screen_desc"
+            android:layout_alignStart="@+id/screen_desc"
+            android:gravity="center_horizontal"
+            android:paddingLeft="24dp"
+            android:paddingRight="24dp"
+            android:text="@{vm.getMessage}"
+            android:textColor="#ffffff"
+            android:textSize="16sp"
+            android:visibility="visible"
+            tools:text="@{vm.getMessage}" />
+
+        <Button
+            android:id="@+id/recover"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/welcomeFixIssue"
-            android:id="@+id/recover"
-            android:visibility="@{vm.fixAvailable}"
-            android:onClick="@{() -> vm.onFixClicked()}"
             android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"/>
+            android:layout_centerHorizontal="true"
+            android:onClick="@{() -> vm.onFixClicked()}"
+            android:text="@string/welcomeFixIssue"
+            android:visibility="@{vm.fixAvailable }" />
 
     </RelativeLayout>
 </layout>

--- a/project/app/src/main/res/values/strings.xml
+++ b/project/app/src/main/res/values/strings.xml
@@ -120,10 +120,10 @@
     <string name="preferencesIgnoreInaccurateLocationsDialog">Ignore location, if the accuracy is greater than the given meters</string>
     <string name="preferencesLocatorInterval">Location interval</string>
     <string name="preferencesLocatorIntervalSummary">Interval between location updates</string>
-    <string name="preferencesLocatorIntervalDialog">How often should locations be requested from the device</string>
+    <string name="preferencesLocatorIntervalDialog">How often should locations be requested from the device (seconds)</string>
     <string name="preferencesMoveModeLocatorInterval">Location interval (Move mode)</string>
     <string name="preferencesMoveModeLocatorIntervalSummary">Interval between location updates in Move mode</string>
-    <string name="preferencesMoveModeLocatorIntervalDialog">How often should locations be requested from the device whilst in Move mode</string>
+    <string name="preferencesMoveModeLocatorIntervalDialog">How often should locations be requested from the device whilst in Move mode (seconds)</string>
 
     <string name="errorPreferencesImportFailedMemory">Your device ran out of memory</string>
     <string name="noNavigationApp">no suitable app installed</string>

--- a/project/app/src/test/java/org/owntracks/android/robolectric/WelcomeActivityTest.java
+++ b/project/app/src/test/java/org/owntracks/android/robolectric/WelcomeActivityTest.java
@@ -96,7 +96,6 @@ public class WelcomeActivityTest {
         // Shows done
         assertEquals(View.GONE, welcomeActivity.findViewById(R.id.btn_next).getVisibility());
         assertEquals(View.VISIBLE, welcomeActivity.findViewById(R.id.done).getVisibility());
-        assertFalse(welcomeActivity.findViewById(R.id.btn_next).isEnabled());
         assertTrue(welcomeActivity.findViewById(R.id.done).isEnabled());
 
         clickOn(welcomeActivity.findViewById(R.id.done));
@@ -117,7 +116,6 @@ public class WelcomeActivityTest {
         // Shows Done
         assertEquals(View.GONE, welcomeActivity.findViewById(R.id.btn_next).getVisibility());
         assertEquals(View.VISIBLE, welcomeActivity.findViewById(R.id.done).getVisibility());
-        assertFalse(welcomeActivity.findViewById(R.id.btn_next).isEnabled());
         assertTrue(welcomeActivity.findViewById(R.id.done).isEnabled());
         clickOn(welcomeActivity.findViewById(R.id.done));
 

--- a/project/app/src/test/java/org/owntracks/android/services/MessageProcessorEndpointHttpTest.java
+++ b/project/app/src/test/java/org/owntracks/android/services/MessageProcessorEndpointHttpTest.java
@@ -164,7 +164,7 @@ public class MessageProcessorEndpointHttpTest {
 
     }
 
-    @Test
+    @Test(expected = ConfigurationIncompleteException.class)
     public void EndpointCorrectlyFailsOnInvalidUrl() throws ConfigurationIncompleteException {
         String[] urls = {"htt://example.com/owntracks/test", "tt://example", "example.com"};
 
@@ -173,8 +173,6 @@ public class MessageProcessorEndpointHttpTest {
             LinkedBlockingDeque<MessageBase> outgoingQueue = new LinkedBlockingDeque<>();
             messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null, outgoingQueue);
             messageProcessorEndpointHttp.checkConfigurationComplete();
-            assertNull(messageProcessorEndpointHttp.getRequest(messageLocation));
         }
     }
-
 }

--- a/project/app/src/test/java/org/owntracks/android/services/MessageProcessorEndpointHttpTest.java
+++ b/project/app/src/test/java/org/owntracks/android/services/MessageProcessorEndpointHttpTest.java
@@ -80,12 +80,12 @@ public class MessageProcessorEndpointHttpTest {
     @Test
     public void EndpointCorrectlyInitializesSelfWithDefaultSettings() {
         when(testPreferences.getUrl()).thenReturn("");
-        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null);
+        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null, outgoingQueue);
     }
 
     @Test
     public void EndpointCorrectlyInitializesRequestWithoutAuth() {
-        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null);
+        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null, outgoingQueue);
 
         assertTrue(messageProcessorEndpointHttp.isConfigurationComplete());
 
@@ -106,7 +106,7 @@ public class MessageProcessorEndpointHttpTest {
         when(testPreferences.getUsername()).thenReturn("username");
         when(testPreferences.getDeviceId()).thenReturn("device");
 
-        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null);
+        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null, outgoingQueue);
         assertTrue(messageProcessorEndpointHttp.isConfigurationComplete());
         okhttp3.Request request = messageProcessorEndpointHttp.getRequest(messageLocation);
         assertNotNull(request);
@@ -120,7 +120,7 @@ public class MessageProcessorEndpointHttpTest {
         when(testPreferences.getUsername()).thenReturn("username");
         when(testPreferences.getPassword()).thenReturn("password");
 
-        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null);
+        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null, outgoingQueue);
         assertTrue(messageProcessorEndpointHttp.isConfigurationComplete());
         okhttp3.Request request = messageProcessorEndpointHttp.getRequest(messageLocation);
         assertNotNull(request);
@@ -137,7 +137,7 @@ public class MessageProcessorEndpointHttpTest {
         when(testPreferences.getPassword()).thenReturn("password_ignored");
         when(testPreferences.getUrl()).thenReturn("http://username_url:password_url@example.com/owntracks/test");
 
-        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null);
+        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null, outgoingQueue);
         assertTrue(messageProcessorEndpointHttp.isConfigurationComplete());
         okhttp3.Request request = messageProcessorEndpointHttp.getRequest(messageLocation);
         assertNotNull(request);
@@ -153,7 +153,7 @@ public class MessageProcessorEndpointHttpTest {
     @Test
     public void EndpointCorrectlyInitializesRequestWithAuthAndEmptyCredentialsFromPreferences() {
         when(testPreferences.getAuth()).thenReturn(true);
-        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null);
+        messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null, outgoingQueue);
 
         assertTrue(messageProcessorEndpointHttp.isConfigurationComplete());
 
@@ -169,7 +169,7 @@ public class MessageProcessorEndpointHttpTest {
 
         for (String url : urls) {
             when(testPreferences.getUrl()).thenReturn(url);
-            messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null);
+            messageProcessorEndpointHttp = new MessageProcessorEndpointHttp(messageProcessor, parser, testPreferences, scheduler, null, outgoingQueue);
             assertFalse(messageProcessorEndpointHttp.isConfigurationComplete());
             assertNull(messageProcessorEndpointHttp.getRequest(messageLocation));
         }


### PR DESCRIPTION
Trying to sort out the MQTT connectivity and outgoing message issues.

New approach is for the LocationProcessor to dump messages onto a deque and spin up a thread that just blocks on dequeueing locationmessages and dispatching them to the endpoint-specific sendmessage. On failure, the failed message is held and then retried later.

Incoming messages are handled on the same thread as the receiver, as they should be low overhead.

TODO:
* [x] implement a better retry backoff handle mechanism. Currently, it just waits a minute. Maybe also trigger a retry on network event?
* [x] investigate whether we want to explicitly disconnect if we get an MqttException. I've seen some weird states the MqttClient gets into on dodgy networks where the state is "connected" but messages timeout. Perhaps resetting the client would help?
* [x] tidy up the incoming message handlers
* [x] test the region transitions still work.
* [x] test the commands still work.
* [x] Some tests would be a good idea.