### PR TITLE
Added switch to global enable geocoding

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/support/GeocoderNone.java
+++ b/project/app/src/main/java/org/owntracks/android/support/GeocoderNone.java
@@ -1,0 +1,12 @@
+package org.owntracks.android.support;
+
+public class GeocoderNone implements Geocoder {
+    GeocoderNone() {
+
+    }
+
+    public String reverse(double latitude, double longitude) {
+        return (latitude + " : " + longitude);
+    }
+
+}

--- a/project/app/src/main/java/org/owntracks/android/support/GeocodingProvider.java
+++ b/project/app/src/main/java/org/owntracks/android/support/GeocodingProvider.java
@@ -30,10 +30,12 @@ public class GeocodingProvider {
     @Inject
     public GeocodingProvider(@AppContext Context context, Preferences preferences) {
         cache = new LruCache<>(40);
-        if("".equals(preferences.getOpenCageGeocoderApiKey())) {
-            geocoder = new GeocoderGoogle(context);
-        } else {
-            geocoder = new GeocoderOpencage(preferences.getOpenCageGeocoderApiKey());
+        if(true == preferences.getGeocode()) {
+            if ("".equals(preferences.getOpenCageGeocoderApiKey())) {
+                geocoder = new GeocoderGoogle(context);
+            } else {
+                geocoder = new GeocoderOpencage(preferences.getOpenCageGeocoderApiKey());
+            }
         }
     }
 
@@ -151,6 +153,10 @@ public class GeocodingProvider {
                 return "Resolve failed";
             }
 
+            if( null == geocoder ) {
+                return m.getGeocoderFallback();
+            }
+
             return geocoder.reverse(m.getLatitude(), m.getLongitude());
         }
 
@@ -159,7 +165,7 @@ public class GeocodingProvider {
         protected void onPostExecute(String result) {
             MessageLocation m = message.get();
             Timber.v("geocoding result: %s", result);
-            if(m!=null && result != null) {
+            if(m != null && result != null) {
                 m.setGeocoder(result);
                 putCache(m, result);
             }

--- a/project/app/src/main/java/org/owntracks/android/support/GeocodingProvider.java
+++ b/project/app/src/main/java/org/owntracks/android/support/GeocodingProvider.java
@@ -30,12 +30,15 @@ public class GeocodingProvider {
     @Inject
     public GeocodingProvider(@AppContext Context context, Preferences preferences) {
         cache = new LruCache<>(40);
-        if(true == preferences.getGeocode()) {
+        if(true == preferences.getGeocodeEnabled()) {
             if ("".equals(preferences.getOpenCageGeocoderApiKey())) {
                 geocoder = new GeocoderGoogle(context);
             } else {
                 geocoder = new GeocoderOpencage(preferences.getOpenCageGeocoderApiKey());
             }
+        }
+        else {
+            geocoder = new GeocoderNone();
         }
     }
 
@@ -151,10 +154,6 @@ public class GeocodingProvider {
             MessageLocation m = message.get();
             if(m == null) {
                 return "Resolve failed";
-            }
-
-            if( null == geocoder ) {
-                return m.getGeocoderFallback();
             }
 
             return geocoder.reverse(m.getLatitude(), m.getLongitude());

--- a/project/app/src/main/java/org/owntracks/android/support/GeocodingProvider.java
+++ b/project/app/src/main/java/org/owntracks/android/support/GeocodingProvider.java
@@ -30,7 +30,7 @@ public class GeocodingProvider {
     @Inject
     public GeocodingProvider(@AppContext Context context, Preferences preferences) {
         cache = new LruCache<>(40);
-        if(true == preferences.getGeocodeEnabled()) {
+        if(preferences.getGeocodeEnabled()) {
             if ("".equals(preferences.getOpenCageGeocoderApiKey())) {
                 geocoder = new GeocoderGoogle(context);
             } else {

--- a/project/app/src/main/java/org/owntracks/android/support/Preferences.java
+++ b/project/app/src/main/java/org/owntracks/android/support/Preferences.java
@@ -940,6 +940,16 @@ public class Preferences {
         sharedPreferences.edit().putBoolean(Keys._OBJECTBOX_MIGRATED, true).apply();
     }
 
+    @Export(key = Keys.GEOCODE, exportModeMqttPrivate = true, exportModeHttpPrivate = true)
+    public boolean getGeocode() {
+        return getBoolean(Keys.GEOCODE, R.bool.valGeocode);
+    }
+
+    @Import(key = Keys.GEOCODE)
+    public void setGeocode(boolean aBoolean) {
+        setBoolean(Keys.GEOCODE, aBoolean);
+    }
+
     @SuppressWarnings("WeakerAccess")
     public static class Keys {
         public static final String AUTH                             = "auth";
@@ -950,6 +960,7 @@ public class Preferences {
         public static final String DEBUG_LOG                        = "debugLog";
         public static final String DONT_REUSE_HTTP_CLIENT           = "dontReuseHttpClient";
         public static final String FUSED_REGION_DETECTION           = "fusedRegionDetection";
+        public static final String GEOCODE                          = "geocode";
         public static final String HOST                             = "host";
         public static final String IGNORE_INACCURATE_LOCATIONS      = "ignoreInaccurateLocations";
         public static final String IGNORE_STALE_LOCATIONS           = "ignoreStaleLocations";

--- a/project/app/src/main/java/org/owntracks/android/support/Preferences.java
+++ b/project/app/src/main/java/org/owntracks/android/support/Preferences.java
@@ -940,14 +940,14 @@ public class Preferences {
         sharedPreferences.edit().putBoolean(Keys._OBJECTBOX_MIGRATED, true).apply();
     }
 
-    @Export(key = Keys.GEOCODE, exportModeMqttPrivate = true, exportModeHttpPrivate = true)
-    public boolean getGeocode() {
-        return getBoolean(Keys.GEOCODE, R.bool.valGeocode);
+    @Export(key = Keys.GEOCODE_ENABLED, exportModeMqttPrivate = true, exportModeHttpPrivate = true)
+    public boolean getGeocodeEnabled() {
+        return getBoolean(Keys.GEOCODE_ENABLED, R.bool.valGeocodeEnabled);
     }
 
-    @Import(key = Keys.GEOCODE)
-    public void setGeocode(boolean aBoolean) {
-        setBoolean(Keys.GEOCODE, aBoolean);
+    @Import(key = Keys.GEOCODE_ENABLED)
+    public void setGeocodeEnabled(boolean aBoolean) {
+        setBoolean(Keys.GEOCODE_ENABLED, aBoolean);
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -960,7 +960,7 @@ public class Preferences {
         public static final String DEBUG_LOG                        = "debugLog";
         public static final String DONT_REUSE_HTTP_CLIENT           = "dontReuseHttpClient";
         public static final String FUSED_REGION_DETECTION           = "fusedRegionDetection";
-        public static final String GEOCODE                          = "geocode";
+        public static final String GEOCODE_ENABLED                  = "geocodeEnabled";
         public static final String HOST                             = "host";
         public static final String IGNORE_INACCURATE_LOCATIONS      = "ignoreInaccurateLocations";
         public static final String IGNORE_STALE_LOCATIONS           = "ignoreStaleLocations";

--- a/project/app/src/main/java/org/owntracks/android/ui/preferences/PreferencesFragment.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/preferences/PreferencesFragment.java
@@ -217,7 +217,7 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
 
 
         addSwitchPreference(misc, Preferences.Keys.AUTOSTART_ON_BOOT, R.string.preferencesAutostart, R.string.preferencesAutostartSummary, R.bool.valAutostartOnBoot);
-        addSwitchPreference(misc, Preferences.Keys.GEOCODE, R.string.preferencesGeocode, R.string.preferencesGeocodeSummary, R.bool.valGeocode);
+        addSwitchPreference(misc, Preferences.Keys.GEOCODE_ENABLED, R.string.preferencesGeocode, R.string.preferencesGeocodeSummary, R.bool.valGeocodeEnabled);
         addEditStringPreference(misc, Preferences.Keys.OPENCAGE_GEOCODER_API_KEY, R.string.preferencesOpencageGeocoderApiKey, R.string.preferencesOpencageGeocoderApiKeySummary, R.string.valEmpty).withDialogMessage(R.string.preferencesOpencageGeocoderApiKeyDialog);
     }
 

--- a/project/app/src/main/java/org/owntracks/android/ui/preferences/PreferencesFragment.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/preferences/PreferencesFragment.java
@@ -217,8 +217,8 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
 
 
         addSwitchPreference(misc, Preferences.Keys.AUTOSTART_ON_BOOT, R.string.preferencesAutostart, R.string.preferencesAutostartSummary, R.bool.valAutostartOnBoot);
+        addSwitchPreference(misc, Preferences.Keys.GEOCODE, R.string.preferencesGeocode, R.string.preferencesGeocodeSummary, R.bool.valGeocode);
         addEditStringPreference(misc, Preferences.Keys.OPENCAGE_GEOCODER_API_KEY, R.string.preferencesOpencageGeocoderApiKey, R.string.preferencesOpencageGeocoderApiKeySummary, R.string.valEmpty).withDialogMessage(R.string.preferencesOpencageGeocoderApiKeyDialog);
-
     }
 
     @Override

--- a/project/app/src/main/res/values-de/strings.xml
+++ b/project/app/src/main/res/values-de/strings.xml
@@ -36,7 +36,7 @@
     <string name="preferencesRemoteCommand">Fernkommandos</string>
     <string name="preferencesRemoteCommandSummary">Fernkommandos aktivieren</string>
     <string name="preferencesGeocode">Geocodierung</string>
-    <string name="preferencesGeocodeSummary">Geocodierung aktivieren</string>
+    <string name="preferencesGeocodeSummary">Geocodierung aktivieren. Erfordert einen Neustart.</string>
     <string name="description">Beschreibung</string>
     <string name="longitude">Längengrad</string>
     <string name="latitude">Breitengrad</string>
@@ -137,7 +137,7 @@
     <string name="notificationChannelEventsDescription">Region transmissions</string>
     <string name="preferencesOpencageGeocoderApiKey">OpenCage API Schlüssel</string>
     <string name="preferencesOpencageGeocoderApiKeySummary">Alternative Geocoder API Schlüssel</string>
-    <string name="preferencesOpencageGeocoderApiKeyDialog">Nutzt OpenCage zur Auflösung von Adressen statt Google Geocoder</string>
+    <string name="preferencesOpencageGeocoderApiKeyDialog">Nutzt OpenCage zur Auflösung von Adressen statt Google Geocoder. Erfordert einen Neustart.</string>
     <string name="region_unknown">Status unbekannt</string>
     <string name="region_inside">Aktuell innerhalb</string>
     <string name="region_outside">Aktuell außerhalb</string>

--- a/project/app/src/main/res/values-de/strings.xml
+++ b/project/app/src/main/res/values-de/strings.xml
@@ -35,6 +35,8 @@
     <string name="preferencesAutostart">Autostart</string>
     <string name="preferencesRemoteCommand">Fernkommandos</string>
     <string name="preferencesRemoteCommandSummary">Fernkommandos aktivieren</string>
+    <string name="preferencesGeocode">Geocodierung</string>
+    <string name="preferencesGeocodeSummary">Geocodierung aktivieren</string>
     <string name="description">Beschreibung</string>
     <string name="longitude">Längengrad</string>
     <string name="latitude">Breitengrad</string>

--- a/project/app/src/main/res/values-es/strings.xml
+++ b/project/app/src/main/res/values-es/strings.xml
@@ -40,7 +40,7 @@
     <string name="preferencesRemoteCommand">Comandos remotos</string>
     <string name="preferencesRemoteCommandSummary">Habilitar comandos remotos</string>
     <string name="preferencesGeocode">Geocodificación</string>
-    <string name="preferencesGeocodeSummary">Habilitar geocodificación</string>
+    <string name="preferencesGeocodeSummary">Habilitar geocodificación. Requiere reiniciar.</string>
     <string name="description">Descripción</string>
     <string name="longitude">Longitud</string>
     <string name="latitude">Latitud</string>
@@ -141,7 +141,7 @@
 	<string name="notificationChannelEventsDescription">Transmisiones regionales</string>
     <string name="preferencesOpencageGeocoderApiKey">OpenCage API Key</string>
     <string name="preferencesOpencageGeocoderApiKeySummary">API key para Geocoder alternativo</string>
-    <string name="preferencesOpencageGeocoderApiKeyDialog">Si se activa, OpenCage se usará para buscar la ubicación en lugar de Google</string>
+    <string name="preferencesOpencageGeocoderApiKeyDialog">Si se activa, OpenCage se usará para buscar la ubicación en lugar de Google. Requiere reiniciar.</string>
     <string name="region_unknown">Estado desconocido</string>
     <string name="region_inside">Actualmente dentro</string>
     <string name="region_outside">Actualmente fuera</string>

--- a/project/app/src/main/res/values-es/strings.xml
+++ b/project/app/src/main/res/values-es/strings.xml
@@ -39,6 +39,8 @@
     <string name="preferencesAutostart">Autoarranque</string>
     <string name="preferencesRemoteCommand">Comandos remotos</string>
     <string name="preferencesRemoteCommandSummary">Habilitar comandos remotos</string>
+    <string name="preferencesGeocode">Geocodificación</string>
+    <string name="preferencesGeocodeSummary">Habilitar geocodificación</string>
     <string name="description">Descripción</string>
     <string name="longitude">Longitud</string>
     <string name="latitude">Latitud</string>

--- a/project/app/src/main/res/values/defaults.xml
+++ b/project/app/src/main/res/values/defaults.xml
@@ -33,7 +33,7 @@
     <bool name="valWs">false</bool>
     <bool name="valUsePassword">true</bool>
     <bool name="valInfo" >true</bool>
-    <bool name="valGeocode">true</bool>
+    <bool name="valGeocodeEnabled">true</bool>
 
     <string-array name="modeIds" translatable="false">
         <item>3</item>

--- a/project/app/src/main/res/values/defaults.xml
+++ b/project/app/src/main/res/values/defaults.xml
@@ -33,6 +33,7 @@
     <bool name="valWs">false</bool>
     <bool name="valUsePassword">true</bool>
     <bool name="valInfo" >true</bool>
+    <bool name="valGeocode">true</bool>
 
     <string-array name="modeIds" translatable="false">
         <item>3</item>

--- a/project/app/src/main/res/values/strings.xml
+++ b/project/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="preferencesRemoteCommand">Remote commands</string>
     <string name="preferencesRemoteCommandSummary">Enable remote commands</string>
     <string name="preferencesGeocode">Geocode</string>
-    <string name="preferencesGeocodeSummary">Enable geocoding</string>
+    <string name="preferencesGeocodeSummary">Enable geocoding. Requires restart.</string>
     <string name="description">Description</string>
     <string name="longitude">Longitude</string>
     <string name="latitude">Latitude</string>
@@ -159,7 +159,7 @@
 	<string name="notificationChannelEventsDescription">Region transmissions</string>
     <string name="preferencesOpencageGeocoderApiKey">OpenCage API Key</string>
     <string name="preferencesOpencageGeocoderApiKeySummary">API key for alternative Geocoder</string>
-    <string name="preferencesOpencageGeocoderApiKeyDialog">If set OpenCage is used to resolve location adresses instead of Google</string>
+    <string name="preferencesOpencageGeocoderApiKeyDialog">If set OpenCage is used to resolve location adresses instead of Google. Requires restart.</string>
     <string name="region_unknown">Status unknown</string>
     <string name="region_inside">Currently inside</string>
     <string name="region_outside">Currently outside</string>

--- a/project/app/src/main/res/values/strings.xml
+++ b/project/app/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="preferencesAutostart">Autostart</string>
     <string name="preferencesRemoteCommand">Remote commands</string>
     <string name="preferencesRemoteCommandSummary">Enable remote commands</string>
+    <string name="preferencesGeocode">Geocode</string>
+    <string name="preferencesGeocodeSummary">Enable geocoding</string>
     <string name="description">Description</string>
     <string name="longitude">Longitude</string>
     <string name="latitude">Latitude</string>


### PR DESCRIPTION
PR I started a while ago and just got around to finishing. Noticed that it addresses #794.

Adds a "Geocoding" boolean switch to Advanced settings to disable the geocoder, no matter which one is selected.

I did not add translations for the settings strings as I'm not a native speaker of anything but English. I'm happy to try and add if necessary.