### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ OwnTracks for Android
 This is the OwnTracks Android app. 
 See our [booklet](http://owntracks.org/booklet/features/android/) for a list of known issues and restrictions. 
 
-![Android CI](https://github.com/owntracks/android/workflows/Android%20CI/badge.svg)
+![Android CI](https://github.com/owntracks/android/workflows/Android%20CI/badge.svg) [![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fowntracks%2Fandroid&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1700)](https://user-images.githubusercontent.com/47092464/98457353-5c8bc280-21c1-11eb-9d7d-aa9ea176837c.png)
