### PR TITLE
Fix links in playstore description.

### DIFF
--- a/project/app/src/main/play/listings/en-US/full-description.txt
+++ b/project/app/src/main/play/listings/en-US/full-description.txt
@@ -1,3 +1,3 @@
 OwnTracks allows you to keep track of your own location. You can build your private location diary or share it with your family and friends. OwnTracks is open-source and uses open protocols for communication so you can be sure your data stays secure and private.
 
-For more information see our documentation (http://owntracks.org/booklet)
+For more information see our documentation (http://owntracks.org/booklet )

--- a/project/app/src/main/play/release-notes/en-US/default.txt
+++ b/project/app/src/main/play/release-notes/en-US/default.txt
@@ -1,3 +1,3 @@
 Release 2.2.2
-All changes can be found at https://github.com/owntracks/android/releases/tag/Android-v2.2.2/CHANGELOG.md
+All changes can be found at https://github.com/owntracks/android/releases/tag/Android-v.2.2.2/CHANGELOG.md
 Please report any issues to https://github.com/owntracks/android/issues


### PR DESCRIPTION
- URL of change log adapted to tagging scheme.
- Changed link to booklet, as play store misinterpreted the closing ) to be
  part of the URL.

Signed-off-by: Holger Friedrich <mail@holger-friedrich.de>