### PR TITLE
Added retries for messages in the queue

### DIFF
--- a/project/app/src/androidTest/java/org/owntracks/android/e2e/Common.kt
+++ b/project/app/src/androidTest/java/org/owntracks/android/e2e/Common.kt
@@ -1,0 +1,14 @@
+package org.owntracks.android.e2e
+
+import com.schibsted.spain.barista.interaction.BaristaClickInteractions
+import org.owntracks.android.R
+
+internal fun doWelcomeProcess() {
+    BaristaClickInteractions.clickOn(R.id.btn_next)
+/* TODO Once test isolation is possible we'll have to grant the priv each test */
+//        clickOn(R.id.btn_next)
+//        clickOn(R.id.fix_permissions_button)
+//        LocationPermissionGranter.allowPermissionsIfNeeded(Manifest.permission.ACCESS_FINE_LOCATION)
+    BaristaClickInteractions.clickOn(R.id.btn_next)
+    BaristaClickInteractions.clickOn(R.id.done)
+}

--- a/project/app/src/main/java/org/owntracks/android/model/messages/MessageBase.kt
+++ b/project/app/src/main/java/org/owntracks/android/model/messages/MessageBase.kt
@@ -10,6 +10,9 @@ import java.io.IOException
 @JsonSubTypes(JsonSubTypes.Type(value = MessageLocation::class, name = MessageLocation.TYPE), JsonSubTypes.Type(value = MessageTransition::class, name = MessageTransition.TYPE), JsonSubTypes.Type(value = MessageCard::class, name = MessageCard.TYPE), JsonSubTypes.Type(value = MessageCmd::class, name = MessageCmd.TYPE), JsonSubTypes.Type(value = MessageConfiguration::class, name = MessageConfiguration.TYPE), JsonSubTypes.Type(value = MessageEncrypted::class, name = MessageEncrypted.TYPE), JsonSubTypes.Type(value = MessageWaypoint::class, name = MessageWaypoint.TYPE), JsonSubTypes.Type(value = MessageWaypoints::class, name = MessageWaypoints.TYPE), JsonSubTypes.Type(value = MessageLwt::class, name = MessageLwt.TYPE))
 @JsonPropertyOrder(alphabetic = true)
 abstract class MessageBase : BaseObservable() {
+    @JsonIgnore
+    open val numberOfRetries: Int = 10
+
     @get:JsonIgnore
     @JsonIgnore
     val messageId = System.currentTimeMillis()

--- a/project/app/src/main/java/org/owntracks/android/model/messages/MessageLocation.kt
+++ b/project/app/src/main/java/org/owntracks/android/model/messages/MessageLocation.kt
@@ -11,7 +11,7 @@ import java.lang.ref.WeakReference
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 open class MessageLocation(private val dep: MessageWithCreatedAt = MessageCreatedAtNow(RealClock())) : MessageBase(), MessageWithCreatedAt by dep {
     @JsonIgnore
-    override val numberOfRetries: Int = 10000 // This should last a week at 1 attempt per minute
+    override val numberOfRetries: Int = 10_080 // This should last a week at 1 attempt per minute
 
     @JsonProperty("t")
     var trigger: String? = null

--- a/project/app/src/main/java/org/owntracks/android/model/messages/MessageLocation.kt
+++ b/project/app/src/main/java/org/owntracks/android/model/messages/MessageLocation.kt
@@ -10,6 +10,9 @@ import java.lang.ref.WeakReference
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 open class MessageLocation(private val dep: MessageWithCreatedAt = MessageCreatedAtNow(RealClock())) : MessageBase(), MessageWithCreatedAt by dep {
+    @JsonIgnore
+    override val numberOfRetries: Int = 10000 // This should last a week at 1 attempt per minute
+
     @JsonProperty("t")
     var trigger: String? = null
 

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
@@ -66,7 +66,7 @@ public class MessageProcessor {
     private Thread backgroundDequeueThread;
 
     private static final long SEND_FAILURE_BACKOFF_INITIAL_WAIT = TimeUnit.SECONDS.toMillis(1);
-    private static final long SEND_FAILURE_BACKOFF_MAX_WAIT = TimeUnit.MINUTES.toMillis(1);
+    private static final long SEND_FAILURE_BACKOFF_MAX_WAIT = TimeUnit.SECONDS.toMillis(10);
 
     private boolean initialized = false;
 

--- a/project/app/src/main/res/layout/ui_status.xml
+++ b/project/app/src/main/res/layout/ui_status.xml
@@ -68,6 +68,7 @@
                     android:text="@string/status_endpoint_state_hint" />
 
                 <TextView
+                    android:id="@+id/connectedStatusMessage"
                     style="@style/ListItemPrimary"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -171,6 +172,7 @@
                         android:paddingBottom="@dimen/activity_horizontal_margin"
                         android:text="@string/status_battery_optimization_whitelisted_hint" />
                 </LinearLayout>
+
                 <ImageView
                     android:layout_width="fill_parent"
                     android:layout_height="1dp"
@@ -178,16 +180,17 @@
                     android:contentDescription="@string/divider"
                     android:scaleType="matrix"
                     android:src="@android:drawable/divider_horizontal_bright" />
+
                 <TextView
                     style="@style/ListItemPrimary"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
                     android:clickable="true"
                     android:focusable="true"
-                    android:background="?android:attr/selectableItemBackground"
                     android:onClick="@{() -> vm.viewLogs()}"
-                    android:paddingTop="@dimen/activity_vertical_margin"
                     android:paddingLeft="@dimen/activity_horizontal_margin"
+                    android:paddingTop="@dimen/activity_vertical_margin"
                     android:paddingRight="@dimen/activity_horizontal_margin"
                     android:paddingBottom="@dimen/activity_vertical_margin"
                     android:text="@string/viewLogs" />


### PR DESCRIPTION
Fixes #936

Current implementation sets a default retry of 10, but overrides it to 10,000 for `MessageLocation` types. The idea here is that all messages should have some retries, but we probably don't want to throw away locations so easily. Devices can be out of network coverage for a long period of time, and a failed send will be retried every minute. 10,000 retries buys up to a week which *feels* like a good threshold, but we might want to do something different.
