### PR TITLE
pretty print exported configurations

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/ui/preferences/editor/EditorActivity.java
+++ b/project/app/src/main/java/org/owntracks/android/ui/preferences/editor/EditorActivity.java
@@ -191,7 +191,7 @@ public class EditorActivity extends BaseActivity<UiPreferencesEditorBinding, Edi
     private String getExportString() throws IOException {
         MessageConfiguration message = preferences.exportToMessage();
         message.setWaypoints(waypointsRepo.exportToMessage());
-        return parser.toJsonPlain(message);
+        return parser.toJsonPlainPretty(message);
     }
 
     static class ExportTask extends AsyncTask<Void, Void, Boolean> {


### PR DESCRIPTION
Pretty printing the exported configurations makes it easier to edit or look at them as files, and I don't really see any downside (the difference in size is really insignificant).