### PR TITLE
use ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS to request battery optimization whitelisting

### DIFF
--- a/project/app/src/main/AndroidManifest.xml
+++ b/project/app/src/main/AndroidManifest.xml
@@ -39,9 +39,6 @@
     <!-- API v28 requires this for foreground services -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-    <!-- To request to be whitelisted from battery optimizations -->
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/project/app/src/main/AndroidManifest.xml
+++ b/project/app/src/main/AndroidManifest.xml
@@ -39,6 +39,9 @@
     <!-- API v28 requires this for foreground services -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <!-- To request to be whitelisted from battery optimizations -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/project/app/src/main/java/org/owntracks/android/ui/status/StatusActivity.kt
+++ b/project/app/src/main/java/org/owntracks/android/ui/status/StatusActivity.kt
@@ -8,6 +8,7 @@ import android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
 import android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import org.owntracks.android.BuildConfig
 import org.owntracks.android.R
 import org.owntracks.android.databinding.UiStatusBinding
 import org.owntracks.android.ui.base.BaseActivity
@@ -28,7 +29,7 @@ class StatusActivity : BaseActivity<UiStatusBinding?, StatusMvvm.ViewModel<Statu
                     .setMessage(getString(R.string.batteryOptimizationWhitelistDialogMessage))
                     .setCancelable(true)
                     .setPositiveButton(getString(R.string.batteryOptimizationWhitelistDialogButtonLabel)) { _, _ ->
-                        if (viewModel?.dozeWhitelisted?.value == true) {
+                        if (viewModel?.dozeWhitelisted?.value == true || BuildConfig.FLAVOR == "gms") {
                             startActivity(
                                 Intent(
                                     ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS

--- a/project/app/src/main/java/org/owntracks/android/ui/status/StatusActivity.kt
+++ b/project/app/src/main/java/org/owntracks/android/ui/status/StatusActivity.kt
@@ -1,9 +1,11 @@
 package org.owntracks.android.ui.status
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
+import android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import org.owntracks.android.R
@@ -26,11 +28,20 @@ class StatusActivity : BaseActivity<UiStatusBinding?, StatusMvvm.ViewModel<Statu
                     .setMessage(getString(R.string.batteryOptimizationWhitelistDialogMessage))
                     .setCancelable(true)
                     .setPositiveButton(getString(R.string.batteryOptimizationWhitelistDialogButtonLabel)) { _, _ ->
-                        startActivity(
-                            Intent(
-                                ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
+                        if (viewModel?.dozeWhitelisted?.value == true) {
+                            startActivity(
+                                Intent(
+                                    ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
+                                )
                             )
-                        )
+                        } else {
+                            startActivity(
+                                Intent(
+                                    ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                                    Uri.parse("package:${packageName}")
+                                )
+                            )
+                        }
                     }.show()
             }
         }

--- a/project/app/src/oss/AndroidManifest.xml
+++ b/project/app/src/oss/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.owntracks.android">
+
+	<!-- To request to be whitelisted from battery optimizations -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+</manifest>


### PR DESCRIPTION
This improves the UX of disabling the battery optimization for OT, as the user just has to click "Allow" instead of setting the filter to "All apps" and searching for OwnTracks in the settings activity manually.