### PR TITLE
enable background location support in osm build

### DIFF
--- a/project/app/src/main/AndroidManifest.xml
+++ b/project/app/src/main/AndroidManifest.xml
@@ -163,7 +163,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="org.owntracks.android.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.java
@@ -40,6 +40,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.jetbrains.annotations.NotNull;
+import org.owntracks.android.BuildConfig;
 import org.owntracks.android.R;
 import org.owntracks.android.data.EndpointState;
 import org.owntracks.android.data.WaypointModel;
@@ -274,7 +275,9 @@ public class BackgroundService extends LifecycleService implements SharedPrefere
                     return;
                 case INTENT_ACTION_BOOT_COMPLETED:
                 case INTENT_ACTION_PACKAGE_REPLACED:
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !hasBeenStartedExplicitly) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                            !hasBeenStartedExplicitly &&
+                            ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_DENIED) {
                         notifyUserOfBackgroundLocationRestriction();
                     }
                     return;

--- a/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.kt
+++ b/project/app/src/main/java/org/owntracks/android/ui/map/MapActivity.kt
@@ -1,7 +1,6 @@
 package org.owntracks.android.ui.map
 
-import android.Manifest.permission.ACCESS_COARSE_LOCATION
-import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.Manifest.permission.*
 import android.content.*
 import android.hardware.Sensor
 import android.hardware.SensorManager

--- a/project/app/src/oss/AndroidManifest.xml
+++ b/project/app/src/oss/AndroidManifest.xml
@@ -3,4 +3,7 @@
 
 	<!-- To request to be whitelisted from battery optimizations -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
+    <!-- To receive location in background service in oss -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 </manifest>


### PR DESCRIPTION
Fixes #1199

Doesn't request background location from the user (as there is no good UI for it), but if you enable it yourself in the settings, owntracks doesn't have to be started manually when rebooting the phone.