### PR TITLE
Added int tests for Float Type preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added Korean translations (#1244, thanks @whatareyoudoingfor)
 - Allow map rotation (#1236)
 - Add a scale bar to the OSM map view (#1263)
+- Allow scaling the OSM map tiles to help with map readability on some devices with the `osmTileScaleFactor` setting (#1223, #1262)
 - [OSS] Allow the user to request background location permission ("All the time") in the device settings (#1255)
 - [OSS] Link straight to the correct battery whitelisting dialog from the status page (#1239)
 

--- a/project/app/src/androidTest/java/org/owntracks/android/ui/ConfigEditorActivityTests.kt
+++ b/project/app/src/androidTest/java/org/owntracks/android/ui/ConfigEditorActivityTests.kt
@@ -40,7 +40,7 @@ class ConfigEditorActivityTests : TestWithAnActivity<EditorActivity>(EditorActiv
     }
 
     @Test
-    fun configurationManagementCanEditAStringType() {
+    fun configurationManagementCanEditAnIntType() {
         openActionBarOverflowOrOptionsMenu(baristaRule.activityTestRule.activity)
         clickOn(R.string.preferencesEditor)
         writeTo(
@@ -50,6 +50,14 @@ class ConfigEditorActivityTests : TestWithAnActivity<EditorActivity>(EditorActiv
         writeTo(R.id.inputValue, "0")
         clickDialogPositiveButton()
 
+        assertContains(
+            R.id.effectiveConfiguration,
+            "\"mode\" : 0"
+        )
+    }
+
+    @Test
+    fun configurationManagementCanEditAStringType() {
         openActionBarOverflowOrOptionsMenu(baristaRule.activityTestRule.activity)
         clickOn(R.string.preferencesEditor)
         writeTo(
@@ -76,6 +84,35 @@ class ConfigEditorActivityTests : TestWithAnActivity<EditorActivity>(EditorActiv
         writeTo(R.id.inputValue, "false")
         clickDialogPositiveButton()
         assertContains(R.id.effectiveConfiguration, "\"cmd\" : false")
+    }
+
+    @Test
+    fun configurationManagementCanEditAFloatType() {
+        openActionBarOverflowOrOptionsMenu(baristaRule.activityTestRule.activity)
+        clickOn(R.string.preferencesEditor)
+        writeTo(
+            R.id.inputKey,
+            baristaRule.activityTestRule.activity.getString(R.string.preferenceKeyOsmTileScaleFactor)
+        )
+        writeTo(R.id.inputValue, "0.5")
+        clickDialogPositiveButton()
+
+        assertContains(
+            R.id.effectiveConfiguration,
+            "\"osmTileScaleFactor\" : 0.5"
+        )
+    }
+
+    @Test
+    fun configurationManagementShowsAnErrorWhenPuttingANonFloatIntoAFloat() {
+        openActionBarOverflowOrOptionsMenu(baristaRule.activityTestRule.activity)
+        clickOn(R.string.preferencesEditor)
+        writeTo(
+            R.id.inputKey,
+            baristaRule.activityTestRule.activity.getString(R.string.preferenceKeyOsmTileScaleFactor)
+        )
+        writeTo(R.id.inputValue, "not a float")
+        clickDialogPositiveButton()
     }
 
     @Test

--- a/project/app/src/main/java/org/owntracks/android/support/Preferences.kt
+++ b/project/app/src/main/java/org/owntracks/android/support/Preferences.kt
@@ -140,8 +140,18 @@ class Preferences @Inject constructor(
         } catch (e: NumberFormatException) {
             throw IllegalArgumentException()
         }
-        if (t is ParameterizedType && Collection::class.java.isAssignableFrom(t.rawType as Class<*>))
+
+        try {
+            if (java.lang.Float.TYPE == t) return value.toFloat()
+        } catch (e: NumberFormatException) {
+            throw IllegalArgumentException()
+        }
+
+        if (t is ParameterizedType &&
+            Collection::class.java.isAssignableFrom(t.rawType as Class<*>)
+        ) {
             return value.split(",").map { it.trim() }.filter { it.isNotBlank() }.toSortedSet()
+        }
         return value
     }
 
@@ -960,6 +970,18 @@ class Preferences @Inject constructor(
             setString(R.string.preferenceKeyMapLayerStyle, newValue.name)
         }
 
+    @get:Export(
+        keyResId = R.string.preferenceKeyOsmTileScaleFactor,
+        exportModeMqtt = true,
+        exportModeHttp = true
+    )
+    @set:Import(keyResId = R.string.preferenceKeyOsmTileScaleFactor)
+    var osmTileScaleFactor: Float
+        get() = getFloatOrDefault(R.string.preferenceKeyOsmTileScaleFactor, 1.0f)
+        set(newValue) {
+            setFloat(R.string.preferenceKeyOsmTileScaleFactor, newValue)
+        }
+
     // Not used on public, as many people might use the same device type
     private val deviceIdDefault: String
         get() = // Use device name (Mako, Surnia, etc. and strip all non alpha digits)
@@ -1128,6 +1150,14 @@ class Preferences @Inject constructor(
 
     private fun getStringSet(resKeyId: Int): Set<String> {
         return preferencesStore.getStringSet(getPreferenceKey(resKeyId))
+    }
+
+    private fun setFloat(resKeyId: Int, value: Float) {
+        preferencesStore.putFloat(getPreferenceKey(resKeyId), value)
+    }
+
+    private fun getFloatOrDefault(resKeyId: Int, default: Float): Float {
+        return preferencesStore.getFloat(getPreferenceKey(resKeyId), default)
     }
 
     private fun clearKey(key: String?) {

--- a/project/app/src/main/java/org/owntracks/android/support/preferences/PreferencesStore.kt
+++ b/project/app/src/main/java/org/owntracks/android/support/preferences/PreferencesStore.kt
@@ -17,6 +17,9 @@ interface PreferencesStore {
     fun putInt(key: String, value: Int)
     fun getInt(key: String, default: Int): Int
 
+    fun putFloat(key: String, value: Float)
+    fun getFloat(key: String, default: Float): Float
+
     fun putString(key: String, value: String)
     fun getString(key: String, default: String): String?
 

--- a/project/app/src/main/java/org/owntracks/android/support/preferences/SharedPreferencesStore.kt
+++ b/project/app/src/main/java/org/owntracks/android/support/preferences/SharedPreferencesStore.kt
@@ -70,6 +70,13 @@ class SharedPreferencesStore @Inject constructor(@ApplicationContext context: Co
         activeSharedPreferences.edit().putInt(key, value).apply()
     }
 
+    override fun getFloat(key: String, default: Float): Float =
+        activeSharedPreferences.getFloat(key, default)
+
+    override fun putFloat(key: String, value: Float) {
+        activeSharedPreferences.edit().putFloat(key, value).apply()
+    }
+
     override fun getSharedPreferencesName(): String = sharedPreferencesName
 
     override fun putStringSet(key: String, values: Set<String>) {

--- a/project/app/src/main/java/org/owntracks/android/ui/map/osm/OSMMapFragment.kt
+++ b/project/app/src/main/java/org/owntracks/android/ui/map/osm/OSMMapFragment.kt
@@ -204,6 +204,7 @@ class OSMMapFragment internal constructor(
             }
             setMultiTouchControls(true)
             isTilesScaledToDpi = true
+            tilesScaleFactor = preferences.osmTileScaleFactor
             viewModel.initMapStartingLocation().run {
                 controller.animateTo(latLng.toGeoPoint(), zoom, 0, rotation)
             }

--- a/project/app/src/main/res/values/donottranslate-preference_keys.xml
+++ b/project/app/src/main/res/values/donottranslate-preference_keys.xml
@@ -33,6 +33,7 @@
     <string name="preferenceKeyNotificationGeocoderErrors">notificationGeocoderErrors</string>
     <string name="preferenceKeyObjectboxMigrated">_objectboxMigrated</string>
     <string name="preferenceKeyOpencageGeocoderApiKey">opencageApiKey</string>
+    <string name="preferenceKeyOsmTileScaleFactor">osmTileScaleFactor</string>
     <string name="preferenceKeyPassword">password</string>
     <string name="preferenceKeyPing">ping</string>
     <string name="preferenceKeyPort">port</string>

--- a/project/app/src/test/java/org/owntracks/android/support/InMemoryPreferencesStore.kt
+++ b/project/app/src/test/java/org/owntracks/android/support/InMemoryPreferencesStore.kt
@@ -33,6 +33,14 @@ class InMemoryPreferencesStore : PreferencesStore {
         return valueMap[key] as Int? ?: default
     }
 
+    override fun putFloat(key: String, value: Float) {
+        valueMap[key] = value
+    }
+
+    override fun getFloat(key: String, default: Float): Float {
+        return valueMap[key] as Float? ?: default
+    }
+
     override fun putString(key: String, value: String) {
         valueMap[key] = value
     }

--- a/project/app/src/test/java/org/owntracks/android/support/PreferencesGettersAndSetters.kt
+++ b/project/app/src/test/java/org/owntracks/android/support/PreferencesGettersAndSetters.kt
@@ -298,6 +298,14 @@ class PreferencesGettersAndSetters(
                     false
                 ),
                 arrayOf(
+                    "OsmTileScaleFactor",
+                    "osmTileScaleFactor",
+                    1.3f,
+                    1.3f,
+                    Float::class,
+                    false
+                ),
+                arrayOf(
                     "Password",
                     "password",
                     "testPassword!\"£",
@@ -423,6 +431,7 @@ class PreferencesGettersAndSetters(
                 on { getString(eq(R.string.preferenceKeyNotificationGeocoderErrors)) } doReturn "notificationGeocoderErrors"
                 on { getString(eq(R.string.preferenceKeyObjectboxMigrated)) } doReturn "_objectboxMigrated"
                 on { getString(eq(R.string.preferenceKeyOpencageGeocoderApiKey)) } doReturn "opencageApiKey"
+                on { getString(eq(R.string.preferenceKeyOsmTileScaleFactor)) } doReturn "osmTileScaleFactor"
                 on { getString(eq(R.string.preferenceKeyPassword)) } doReturn "password"
                 on { getString(eq(R.string.preferenceKeyPing)) } doReturn "ping"
                 on { getString(eq(R.string.preferenceKeyPort)) } doReturn "port"


### PR DESCRIPTION
- Added osmTileScaleFactor preference to allow control of how large the OSM tiles are drawn, to help with readability (#1223)
- Added unit test for osmScalingFactor
- Added espresso tests for Float Config types
