### PR TITLE
Add "republish on reconnect" preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - When displayed, LanLngs now are limited to 6 significant figures, because more precision than that is a bit silly (#1278, #1279)
 - The config editor text is now selectable
 - No need to restart the app once loading in a config any more!
+- Add an option for a location message to be republished on reconnection to MQTT (#1273, #1178)
 
 ### Bug fixes
 

--- a/project/app/src/main/java/org/owntracks/android/model/messages/MessageWithCreatedAt.kt
+++ b/project/app/src/main/java/org/owntracks/android/model/messages/MessageWithCreatedAt.kt
@@ -1,6 +1,7 @@
 package org.owntracks.android.model.messages
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import kotlin.time.Duration.Companion.milliseconds
 
 interface MessageWithCreatedAt {
     @get:JsonProperty("created_at")
@@ -16,5 +17,5 @@ interface Clock {
 }
 
 class RealClock : Clock {
-    override val time: Long = java.util.concurrent.TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())
+    override val time: Long = System.currentTimeMillis().milliseconds.inWholeSeconds
 }

--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.java
@@ -196,7 +196,7 @@ public class MessageProcessor {
                 break;
             case MessageProcessorEndpointMqtt.MODE_ID:
             default:
-                this.endpoint = new MessageProcessorEndpointMqtt(this, this.parser, this.preferences, this.scheduler, this.eventBus, this.runThingsOnOtherThreads, this.applicationContext);
+                this.endpoint = new MessageProcessorEndpointMqtt(this, this.parser, this.preferences, this.scheduler, this.eventBus, this.runThingsOnOtherThreads, this.applicationContext, this.locationProcessorLazy.get());
 
         }
 
@@ -326,6 +326,10 @@ public class MessageProcessor {
         Timber.w("Exiting outgoingmessage loop");
     }
 
+    /**
+     * Resets the retry backoff timer back to the initial value, because we've most likely had a
+     * reconnection event.
+     */
     public void resetMessageSleepBlock() {
         if (waitFuture != null && waitFuture.cancel(false)) {
             Timber.d("Resetting message send loop wait. Thread: %s", Thread.currentThread());

--- a/project/app/src/main/java/org/owntracks/android/support/Preferences.kt
+++ b/project/app/src/main/java/org/owntracks/android/support/Preferences.kt
@@ -9,6 +9,14 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.*
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.greenrobot.eventbus.EventBus
 import org.owntracks.android.BuildConfig
@@ -23,14 +31,6 @@ import org.owntracks.android.support.preferences.PreferencesStore
 import org.owntracks.android.ui.AppShortcuts
 import org.owntracks.android.ui.map.MapLayerStyle
 import timber.log.Timber
-import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.Method
-import java.lang.reflect.ParameterizedType
-import java.lang.reflect.Type
-import java.util.*
-import java.util.concurrent.TimeUnit
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 @SuppressLint("NonConstantResourceId")
@@ -91,11 +91,15 @@ class Preferences @Inject constructor(
     // SharedPreferencesImpl stores its listeners as a list of WeakReferences. So we shouldn't use a
     // lambda as a listener, as that'll just get GC'd and then mysteriously disappear
     // https://stackoverflow.com/a/3104265/352740
-    fun registerOnPreferenceChangedListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+    fun registerOnPreferenceChangedListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener
+    ) {
         preferencesStore.registerOnSharedPreferenceChangeListener(listener)
     }
 
-    fun unregisterOnPreferenceChangedListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+    fun unregisterOnPreferenceChangedListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener
+    ) {
         preferencesStore.unregisterOnSharedPreferenceChangeListener(listener)
     }
 
@@ -203,7 +207,9 @@ class Preferences @Inject constructor(
                         ) {
                             importMethod.invoke(
                                 this,
-                                MonitoringMode.getByValue(messageConfiguration[configurationKey] as Int)
+                                MonitoringMode.getByValue(
+                                    messageConfiguration[configurationKey] as Int
+                                )
                             )
                         } else {
                             importMethod.invoke(this, messageConfiguration[configurationKey])
@@ -213,7 +219,7 @@ class Preferences @Inject constructor(
                     Timber.e(
                         "Tried to import $configurationKey but value is wrong type. Expected: ${
                         methods.getValue(configurationKey).parameterTypes.first().canonicalName
-                        }, given ${messageConfiguration[configurationKey]?.javaClass?.canonicalName}",
+                        }, given ${messageConfiguration[configurationKey]?.javaClass?.canonicalName}"
                     )
                 }
             }
@@ -918,8 +924,12 @@ class Preferences @Inject constructor(
             setInt(R.string.preferenceKeyTheme, actualValue)
             when (actualValue) {
                 NIGHT_MODE_AUTO -> AppCompatDelegate.setDefaultNightMode(SYSTEM_NIGHT_AUTO_MODE)
-                NIGHT_MODE_ENABLE -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-                NIGHT_MODE_DISABLE -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+                NIGHT_MODE_ENABLE -> AppCompatDelegate.setDefaultNightMode(
+                    AppCompatDelegate.MODE_NIGHT_YES
+                )
+                NIGHT_MODE_DISABLE -> AppCompatDelegate.setDefaultNightMode(
+                    AppCompatDelegate.MODE_NIGHT_NO
+                )
             }
         }
 
@@ -989,21 +999,27 @@ class Preferences @Inject constructor(
     )
     @set:Import(keyResId = R.string.preferenceKeyEnableMapRotation)
     var enableMapRotation: Boolean
-        get() = getBooleanOrDefault(R.string.preferenceKeyEnableMapRotation, R.bool.valEnableMapRotation)
+        get() = getBooleanOrDefault(
+            R.string.preferenceKeyEnableMapRotation,
+            R.bool.valEnableMapRotation
+        )
         set(newValue) {
             setBoolean(R.string.preferenceKeyEnableMapRotation, newValue)
         }
 
     @get:Export(
-        keyResId = R.string.preferenceKeyRepublishOnReconnect,
+        keyResId = R.string.preferenceKeyPublishLocationOnConnect,
         exportModeMqtt = true,
         exportModeHttp = false
     )
-    @set:Import(keyResId = R.string.preferenceKeyRepublishOnReconnect)
-    var republishOnReconnect: Boolean
-        get() = getBooleanOrDefault(R.string.preferenceKeyRepublishOnReconnect, R.bool.valRepublishOnRecconect)
+    @set:Import(keyResId = R.string.preferenceKeyPublishLocationOnConnect)
+    var publishLocationOnConnect: Boolean
+        get() = getBooleanOrDefault(
+            R.string.preferenceKeyPublishLocationOnConnect,
+            R.bool.valPublishLocationOnConnect
+        )
         set(newValue) {
-            setBoolean(R.string.preferenceKeyRepublishOnReconnect, newValue)
+            setBoolean(R.string.preferenceKeyPublishLocationOnConnect, newValue)
         }
 
     // Not used on public, as many people might use the same device type

--- a/project/app/src/main/java/org/owntracks/android/support/Preferences.kt
+++ b/project/app/src/main/java/org/owntracks/android/support/Preferences.kt
@@ -994,6 +994,18 @@ class Preferences @Inject constructor(
             setBoolean(R.string.preferenceKeyEnableMapRotation, newValue)
         }
 
+    @get:Export(
+        keyResId = R.string.preferenceKeyRepublishOnReconnect,
+        exportModeMqtt = true,
+        exportModeHttp = false
+    )
+    @set:Import(keyResId = R.string.preferenceKeyRepublishOnReconnect)
+    var republishOnReconnect: Boolean
+        get() = getBooleanOrDefault(R.string.preferenceKeyRepublishOnReconnect, R.bool.valRepublishOnRecconect)
+        set(newValue) {
+            setBoolean(R.string.preferenceKeyRepublishOnReconnect, newValue)
+        }
+
     // Not used on public, as many people might use the same device type
     private val deviceIdDefault: String
         get() = // Use device name (Mako, Surnia, etc. and strip all non alpha digits)

--- a/project/app/src/main/res/values/defaults.xml
+++ b/project/app/src/main/res/values/defaults.xml
@@ -34,6 +34,7 @@
     <bool name="valRemoteConfiguration">false</bool>
     <bool name="valShowRegionsOnMap">false</bool>
     <bool name="valEnableMapRotation">true</bool>
+    <bool name="valRepublishOnRecconect">false</bool>
     <bool name="valPegLocatorFastestIntervalToInterval">false</bool>
 
     <string name="valEmpty" translatable="false" />

--- a/project/app/src/main/res/values/defaults.xml
+++ b/project/app/src/main/res/values/defaults.xml
@@ -34,7 +34,7 @@
     <bool name="valRemoteConfiguration">false</bool>
     <bool name="valShowRegionsOnMap">false</bool>
     <bool name="valEnableMapRotation">true</bool>
-    <bool name="valRepublishOnRecconect">false</bool>
+    <bool name="valPublishLocationOnConnect">false</bool>
     <bool name="valPegLocatorFastestIntervalToInterval">false</bool>
 
     <string name="valEmpty" translatable="false" />

--- a/project/app/src/main/res/values/donottranslate-preference_keys.xml
+++ b/project/app/src/main/res/values/donottranslate-preference_keys.xml
@@ -44,7 +44,7 @@
     <string name="preferenceKeyPubTopicBase">pubTopicBase</string>
     <string name="preferenceKeyRemoteCommand">cmd</string>
     <string name="preferenceKeyRemoteConfiguration">remoteConfiguration</string>
-    <string name="preferenceKeyRepublishOnReconnect">republishOnReconnect</string>
+    <string name="preferenceKeyPublishLocationOnConnect">publishOnConnect</string>
     <string name="preferenceKeySetupNotCompleted">setupNotCompleted</string>
     <string name="preferenceKeySub">sub</string>
     <string name="preferenceKeySubQos">subQos</string>

--- a/project/app/src/main/res/values/donottranslate-preference_keys.xml
+++ b/project/app/src/main/res/values/donottranslate-preference_keys.xml
@@ -44,6 +44,7 @@
     <string name="preferenceKeyPubTopicBase">pubTopicBase</string>
     <string name="preferenceKeyRemoteCommand">cmd</string>
     <string name="preferenceKeyRemoteConfiguration">remoteConfiguration</string>
+    <string name="preferenceKeyRepublishOnReconnect">republishOnReconnect</string>
     <string name="preferenceKeySetupNotCompleted">setupNotCompleted</string>
     <string name="preferenceKeySub">sub</string>
     <string name="preferenceKeySubQos">subQos</string>

--- a/project/app/src/main/res/values/strings.xml
+++ b/project/app/src/main/res/values/strings.xml
@@ -211,6 +211,8 @@ To allow this, please enable Location in the device settings."</string>
     <string name="preferencesRemoteConfigurationSummary">"Enable configuration to be updated remotely (requires remote commands)"</string>
     <string name="preferencesReporting">"Reporting"</string>
     <string name="preferencesRepository">"Source Code"</string>
+    <string name="preferencesRepublishOnRecconect">"Republish on MQTT reconnect"</string>
+    <string name="preferencesRepublishOnRecconectSummary">"Publish the last known location and current extended data on re-connecting to MQTT"</string>
     <string name="preferencesReverseGeocodeProvider">"Reverse Geocode Provider"</string>
     <string name="preferencesSecurity">"Security"</string>
     <string name="preferencesServer">"Connection"</string>

--- a/project/app/src/main/res/values/strings.xml
+++ b/project/app/src/main/res/values/strings.xml
@@ -211,8 +211,8 @@ To allow this, please enable Location in the device settings."</string>
     <string name="preferencesRemoteConfigurationSummary">"Enable configuration to be updated remotely (requires remote commands)"</string>
     <string name="preferencesReporting">"Reporting"</string>
     <string name="preferencesRepository">"Source Code"</string>
-    <string name="preferencesRepublishOnRecconect">"Republish on MQTT reconnect"</string>
-    <string name="preferencesRepublishOnRecconectSummary">"Publish the last known location and current extended data on re-connecting to MQTT"</string>
+    <string name="preferencesRepublishOnRecconect">"Publish location on MQTT connect"</string>
+    <string name="preferencesRepublishOnRecconectSummary">"Publish the last known location and current extended data immediately on connecting to MQTT"</string>
     <string name="preferencesReverseGeocodeProvider">"Reverse Geocode Provider"</string>
     <string name="preferencesSecurity">"Security"</string>
     <string name="preferencesServer">"Connection"</string>

--- a/project/app/src/main/res/xml/preferences_reporting.xml
+++ b/project/app/src/main/res/xml/preferences_reporting.xml
@@ -4,7 +4,13 @@
     <androidx.preference.SwitchPreferenceCompat
         app:defaultValue="@bool/valPubExtendedData"
         app:iconSpaceReserved="false"
-        app:key="pubExtendedData"
+        app:key="@string/preferenceKeyPublishExtendedData"
         app:summary="@string/preferencesPubExtendedDataSummary"
         app:title="@string/preferencesPubExtendedData" />
+    <androidx.preference.SwitchPreferenceCompat
+        app:defaultValue="@bool/valRepublishOnRecconect"
+        app:iconSpaceReserved="false"
+        app:key="@string/preferenceKeyRepublishOnReconnect"
+        app:summary="@string/preferencesRepublishOnRecconectSummary"
+        app:title="@string/preferencesRepublishOnRecconect" />
 </PreferenceScreen>

--- a/project/app/src/main/res/xml/preferences_reporting.xml
+++ b/project/app/src/main/res/xml/preferences_reporting.xml
@@ -8,9 +8,9 @@
         app:summary="@string/preferencesPubExtendedDataSummary"
         app:title="@string/preferencesPubExtendedData" />
     <androidx.preference.SwitchPreferenceCompat
-        app:defaultValue="@bool/valRepublishOnRecconect"
+        app:defaultValue="@bool/valPublishLocationOnConnect"
         app:iconSpaceReserved="false"
-        app:key="@string/preferenceKeyRepublishOnReconnect"
+        app:key="@string/preferenceKeyPublishLocationOnConnect"
         app:summary="@string/preferencesRepublishOnRecconectSummary"
         app:title="@string/preferencesRepublishOnRecconect" />
 </PreferenceScreen>

--- a/project/app/src/test/java/org/owntracks/android/services/MessageProcessorEndpointMqttTest.kt
+++ b/project/app/src/test/java/org/owntracks/android/services/MessageProcessorEndpointMqttTest.kt
@@ -15,7 +15,7 @@ class MessageProcessorEndpointMqttTest {
     @Test
     fun `MQTT Endpoint generates correct topics to subscribe to from single default subTopic`() {
         val endpoint =
-            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext)
+            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext, null)
         val subTopic = "owntracks/+/+"
         val topics =
             endpoint.getTopicsToSubscribeTo(subTopic, true, "/info", "/events", "/waypoints")
@@ -33,7 +33,7 @@ class MessageProcessorEndpointMqttTest {
     @Test
     fun `MQTT Endpoint generates correct topics to subscribe to from single custom subTopic`() {
         val endpoint =
-            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext)
+            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext, null)
         val subTopic = "othertopic/+/+"
         val topics =
             endpoint.getTopicsToSubscribeTo(subTopic, true, "/info", "/events", "/waypoints")
@@ -45,7 +45,7 @@ class MessageProcessorEndpointMqttTest {
     @Test
     fun `MQTT Endpoint generates correct topics to subscribe to from multiple subTopics`() {
         val endpoint =
-            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext)
+            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext, null)
         val subTopic = "owntracks/+/+ othertopic/+"
         val topics =
             endpoint.getTopicsToSubscribeTo(subTopic, true, "/info", "/events", "/waypoints")
@@ -61,7 +61,7 @@ class MessageProcessorEndpointMqttTest {
     @Test
     fun `MQTT Endpoint generates correct topics to subscribe to from multiple subTopics with info not requested`() {
         val endpoint =
-            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext)
+            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext, null)
         val subTopic = "owntracks/+/+ othertopic/+"
         val topics =
             endpoint.getTopicsToSubscribeTo(subTopic, false, "/info", "/events", "/waypoints")
@@ -77,7 +77,7 @@ class MessageProcessorEndpointMqttTest {
     @Test
     fun `MQTT Endpoint generates correct topics to subscribe to from wildcard topic`() {
         val endpoint =
-            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext)
+            MessageProcessorEndpointMqtt(null, null, null, null, null, null, applicationContext, null)
         val subTopic = "owntracks/#"
         val topics =
             endpoint.getTopicsToSubscribeTo(subTopic, true, "/info", "/events", "/waypoints")

--- a/project/app/src/test/java/org/owntracks/android/support/ParserTest.kt
+++ b/project/app/src/test/java/org/owntracks/android/support/ParserTest.kt
@@ -40,7 +40,7 @@ class ParserTest {
         val regions: MutableList<String> = LinkedList()
         regions.add("Testregion1")
         regions.add("Testregion2")
-        messageLocation = MessageLocation(MessageCreatedAtNow(FakeClock())).apply {
+        messageLocation = MessageLocation(MessageCreatedAtNow(FakeFixedClock())).apply {
             accuracy = 10
             altitude = 20
             latitude = 50.1
@@ -711,7 +711,7 @@ class ParserTest {
     }
     //endregion
 
-    inner class FakeClock : Clock {
+    inner class FakeFixedClock : Clock {
         override val time: Long = 25
     }
 }

--- a/project/app/src/test/java/org/owntracks/android/support/PreferencesGettersAndSetters.kt
+++ b/project/app/src/test/java/org/owntracks/android/support/PreferencesGettersAndSetters.kt
@@ -363,8 +363,8 @@ class PreferencesGettersAndSetters(
                     false
                 ),
                 arrayOf(
-                    "RepublishOnReconnect",
-                    "republishOnReconnect",
+                    "PublishLocationOnConnect",
+                    "publishLocationOnConnect",
                     true,
                     true,
                     Boolean::class,
@@ -454,12 +454,12 @@ class PreferencesGettersAndSetters(
                 on { getString(eq(R.string.preferenceKeyPing)) } doReturn "ping"
                 on { getString(eq(R.string.preferenceKeyPort)) } doReturn "port"
                 on { getString(eq(R.string.preferenceKeyPublishExtendedData)) } doReturn "pubExtendedData"
+                on { getString(eq(R.string.preferenceKeyPublishLocationOnConnect)) } doReturn "publishLocationOnConnect"
                 on { getString(eq(R.string.preferenceKeyPubQos)) } doReturn "pubQos"
                 on { getString(eq(R.string.preferenceKeyPubRetain)) } doReturn "pubRetain"
                 on { getString(eq(R.string.preferenceKeyPubTopicBase)) } doReturn "pubTopicBase"
                 on { getString(eq(R.string.preferenceKeyRemoteCommand)) } doReturn "cmd"
                 on { getString(eq(R.string.preferenceKeyRemoteConfiguration)) } doReturn "remoteConfiguration"
-                on { getString(eq(R.string.preferenceKeyPublishLocationOnConnect)) } doReturn "republishOnReconnect"
                 on { getString(eq(R.string.preferenceKeyReverseGeocodeProvider)) } doReturn "reverseGeocodeProvider"
                 on { getString(eq(R.string.preferenceKeySetupNotCompleted)) } doReturn "setupNotCompleted"
                 on { getString(eq(R.string.preferenceKeySub)) } doReturn "sub"

--- a/project/app/src/test/java/org/owntracks/android/support/PreferencesGettersAndSetters.kt
+++ b/project/app/src/test/java/org/owntracks/android/support/PreferencesGettersAndSetters.kt
@@ -459,7 +459,7 @@ class PreferencesGettersAndSetters(
                 on { getString(eq(R.string.preferenceKeyPubTopicBase)) } doReturn "pubTopicBase"
                 on { getString(eq(R.string.preferenceKeyRemoteCommand)) } doReturn "cmd"
                 on { getString(eq(R.string.preferenceKeyRemoteConfiguration)) } doReturn "remoteConfiguration"
-                on { getString(eq(R.string.preferenceKeyRepublishOnReconnect)) } doReturn "republishOnReconnect"
+                on { getString(eq(R.string.preferenceKeyPublishLocationOnConnect)) } doReturn "republishOnReconnect"
                 on { getString(eq(R.string.preferenceKeyReverseGeocodeProvider)) } doReturn "reverseGeocodeProvider"
                 on { getString(eq(R.string.preferenceKeySetupNotCompleted)) } doReturn "setupNotCompleted"
                 on { getString(eq(R.string.preferenceKeySub)) } doReturn "sub"

--- a/project/app/src/test/java/org/owntracks/android/support/PreferencesGettersAndSetters.kt
+++ b/project/app/src/test/java/org/owntracks/android/support/PreferencesGettersAndSetters.kt
@@ -362,6 +362,14 @@ class PreferencesGettersAndSetters(
                     Boolean::class,
                     false
                 ),
+                arrayOf(
+                    "RepublishOnReconnect",
+                    "republishOnReconnect",
+                    true,
+                    true,
+                    Boolean::class,
+                    false
+                ),
                 arrayOf("Sub", "sub", true, true, Boolean::class, false),
                 arrayOf("SubQos", "subQos", 1, 1, Int::class, false),
                 arrayOf(
@@ -451,6 +459,7 @@ class PreferencesGettersAndSetters(
                 on { getString(eq(R.string.preferenceKeyPubTopicBase)) } doReturn "pubTopicBase"
                 on { getString(eq(R.string.preferenceKeyRemoteCommand)) } doReturn "cmd"
                 on { getString(eq(R.string.preferenceKeyRemoteConfiguration)) } doReturn "remoteConfiguration"
+                on { getString(eq(R.string.preferenceKeyRepublishOnReconnect)) } doReturn "republishOnReconnect"
                 on { getString(eq(R.string.preferenceKeyReverseGeocodeProvider)) } doReturn "reverseGeocodeProvider"
                 on { getString(eq(R.string.preferenceKeySetupNotCompleted)) } doReturn "setupNotCompleted"
                 on { getString(eq(R.string.preferenceKeySub)) } doReturn "sub"

--- a/util/mqtt-local/mosquitto.conf
+++ b/util/mqtt-local/mosquitto.conf
@@ -1,4 +1,5 @@
 allow_anonymous false
+log_type all
 password_file /mosquitto/config/mosquitto.password
 
 listener 1883


### PR DESCRIPTION
#1178

Adds a preference to allow a user to indicate that a location + extended data should be re-published when MQTT is reconnected after a disconnect.
