### PR TITLE
Use a proper, recent version of BouncyCastle

### DIFF
--- a/project/app/build.gradle.kts
+++ b/project/app/build.gradle.kts
@@ -214,6 +214,8 @@ dependencies {
     implementation(libs.apache.httpcore)
     implementation(libs.commons.codec)
 
+    implementation(libs.bouncycastle)
+
     // Widget libraries
     implementation(libs.widgets.materialedittext)
     implementation(libs.widgets.materialdrawer) { artifact { type = "aar" } }

--- a/project/app/build.gradle.kts
+++ b/project/app/build.gradle.kts
@@ -214,6 +214,8 @@ dependencies {
     implementation(libs.apache.httpcore)
     implementation(libs.commons.codec)
 
+    // The BC version shipped under com.android is half-broken. Weird certificate issues etc.
+    // To solve, we bring in our own version of BC
     implementation(libs.bouncycastle)
 
     // Widget libraries

--- a/project/app/src/main/java/org/owntracks/android/App.kt
+++ b/project/app/src/main/java/org/owntracks/android/App.kt
@@ -70,6 +70,8 @@ class App : Application(), Configuration.Provider {
                 Conscrypt.newProviderBuilder().provideTrustManager(false).build(), 1
             )
         }
+
+        // Bring in a real version of BC and don't use the device version.
         Security.removeProvider("BC")
         Security.addProvider(BouncyCastleProvider())
 

--- a/project/app/src/main/java/org/owntracks/android/App.kt
+++ b/project/app/src/main/java/org/owntracks/android/App.kt
@@ -15,6 +15,7 @@ import androidx.work.Configuration
 import androidx.work.WorkerFactory
 import dagger.hilt.EntryPoints
 import dagger.hilt.android.HiltAndroidApp
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.conscrypt.Conscrypt
 import org.owntracks.android.di.CustomBindingComponentBuilder
 import org.owntracks.android.di.CustomBindingEntryPoint
@@ -69,6 +70,8 @@ class App : Application(), Configuration.Provider {
                 Conscrypt.newProviderBuilder().provideTrustManager(false).build(), 1
             )
         }
+        Security.removeProvider("BC")
+        Security.addProvider(BouncyCastleProvider())
 
         super.onCreate()
 

--- a/project/app/src/main/java/org/owntracks/android/support/SocketFactory.java
+++ b/project/app/src/main/java/org/owntracks/android/support/SocketFactory.java
@@ -8,6 +8,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.Security;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -113,7 +114,7 @@ public class SocketFactory extends javax.net.ssl.SSLSocketFactory{
         if (options.hasClientP12Crt()) {
             Timber.v("options.hasClientP12Crt(): true");
 
-            KeyStore clientKeyStore = KeyStore.getInstance("PKCS12");
+            KeyStore clientKeyStore = KeyStore.getInstance("PKCS12", Security.getProvider("BC"));
 
             clientKeyStore.load(options.getCaClientP12InputStream(), options.hasClientP12Password() ? options.getCaClientP12Password().toCharArray() : new char[0]);
             kmf.init(clientKeyStore, options.hasClientP12Password() ? options.getCaClientP12Password().toCharArray() : new char[0]);

--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ materialdrawer = "6.1.2"
 preferencex = "1.1.0"
 r8 = "3.3.75"
 guava = "31.1-jre"
+bouncycastle = "1.72"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -95,7 +96,6 @@ androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.re
 androidx-test-espresso-idling = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "androidx-test-espresso" }
 
 osmdroid = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid" }
-conscrypt = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
 google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
 eventbus = { module = "org.greenrobot:eventbus", version.ref = "eventbus" }
 eventbus-annotationprocessor = { module = "org.greenrobot:eventbus-annotation-processor", version.ref = "eventbus" }
@@ -118,6 +118,9 @@ square-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android-instr
 
 r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+
+conscrypt = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
+bouncycastle = { module = "org.bouncycastle:bcpkix-jdk15to18", version.ref = "bouncycastle" }
 
 [bundles]
 jackson = ["jackson-core", "jackson-databind", "jackson-module-kotlin", "jackson-datatype-jsr310", "jackson-threetenbp", "threetenbp"]


### PR DESCRIPTION
#1225 raised an issue where there's some certificate oddness on certain devices under certain circumstances. It seems like the version of BouncyCastle that's vendored by android under com.android.org.bouncycastle isn't actually a complete, always-working version of BC (as well as being somewhat out of date).

A bit like the conscrypt saga, we can try and bring some stability by just importing a proper BC implementation with the app and using that instead of the device-provided version. Hopefully this will squash weird certificate issues.

Fixes #1225
