### PR TITLE
Fix: Read Timeout for HTTPS connections because of SO_TIMEOUT configured with seconds but should be in milliseconds

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/net/ConnectionConfiguration.kt
+++ b/project/app/src/main/java/org/owntracks/android/net/ConnectionConfiguration.kt
@@ -3,6 +3,7 @@ package org.owntracks.android.net
 import android.content.Context
 import java.security.KeyStore
 import org.owntracks.android.support.SocketFactory
+import java.util.concurrent.TimeUnit
 
 interface ConnectionConfiguration {
   fun validate()
@@ -16,7 +17,7 @@ interface ConnectionConfiguration {
   ): SocketFactory =
       SocketFactory(
           SocketFactory.SocketFactoryOptions().apply {
-            socketTimeout = connectionTimeoutSeconds
+            socketTimeout = TimeUnit.SECONDS.toMillis(connectionTimeoutSeconds.toLong()).toInt()
             if (tls) {
               clientCertificateAlias = tlsClientCrt
             }

--- a/project/app/src/main/java/org/owntracks/android/net/ConnectionConfiguration.kt
+++ b/project/app/src/main/java/org/owntracks/android/net/ConnectionConfiguration.kt
@@ -2,8 +2,8 @@ package org.owntracks.android.net
 
 import android.content.Context
 import java.security.KeyStore
-import org.owntracks.android.support.SocketFactory
 import java.util.concurrent.TimeUnit
+import org.owntracks.android.support.SocketFactory
 
 interface ConnectionConfiguration {
   fun validate()

--- a/project/app/src/main/java/org/owntracks/android/net/http/HttpMessageProcessorEndpoint.kt
+++ b/project/app/src/main/java/org/owntracks/android/net/http/HttpMessageProcessorEndpoint.kt
@@ -167,6 +167,7 @@ class HttpMessageProcessorEndpoint(
           messageProcessor.onMessageDelivered()
         }
       } catch (e: Exception) {
+        Timber.d(e, "Execute call failed")
         // Sometimes we get an exception just on the execute() call
         throw OutgoingMessageSendingException(e)
       }


### PR DESCRIPTION
I noticed with v2.5.0 that my HTTPS connection was always failing with "Read Timeout".

I think it's because of the TLS 1.1 / 1.2 drop or the switch to the system truststore and maybe that resulted in an increased connection time.

I did some debugging and found that the socket SO_TIMEOUT is configured in seconds, but the documentation says it should be in milliseconds. So I changed that.

I also added debug level exception logging for the generic "execute failed" exception catch block.