### PR TITLE
Assign a default fastest interval.

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/services/BackgroundService.kt
+++ b/project/app/src/main/java/org/owntracks/android/services/BackgroundService.kt
@@ -486,6 +486,8 @@ class BackgroundService : LifecycleService(), Preferences.OnPreferenceChangeList
     }
     if (preferences.pegLocatorFastestIntervalToInterval) {
       fastestInterval = interval
+    } else {
+      fastestInterval = Duration.ofSeconds(1)
     }
     val request =
         LocationRequest(fastestInterval, smallestDisplacement, null, null, priority, interval, null)


### PR DESCRIPTION
Not sure if it's an artifact of the 2.5.x changes, or something Google changed on Android 14 (Pixel 7), but passing a null for fastest interval is just defaulting to interval.

When this is null, `pegLocatorFastestIntervalToInterval ` is resulting in `interval ` if it is true or false.

After this PR, it will report as fast as 1-second when false, to the interval when true.