### PR TITLE
Added `cmd` field to the `status` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## New features
 
 - OSM map is a little easier to zoom without accidentally rotating.
+- Added `cmd` field to the `status` command to retrieve if `remoteConfiguration` is allowed
 
 ## Version 2.5.2
 

--- a/project/app/src/main/java/org/owntracks/android/model/messages/MessageStatus.kt
+++ b/project/app/src/main/java/org/owntracks/android/model/messages/MessageStatus.kt
@@ -47,4 +47,6 @@ class AddMessageStatus {
   @JsonProperty("hib") var appHibernation = 0
 
   @JsonProperty("loc") var locationPermission = 0
+
+  @JsonProperty("cmd") var remoteConfiguration = 0
 }

--- a/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.kt
+++ b/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.kt
@@ -257,6 +257,7 @@ constructor(
                 batteryOptimizations = deviceMetricsProvider.batteryOptimizations
                 appHibernation = deviceMetricsProvider.appHibernation
                 locationPermission = deviceMetricsProvider.locationPermission
+                remoteConfiguration = preferences.remoteConfiguration.compareTo(false)
               }
         })
     publishResponseMessageIdlingResource.setIdleState(true)

--- a/project/app/src/test/java/org/owntracks/android/model/ParserTest.kt
+++ b/project/app/src/test/java/org/owntracks/android/model/ParserTest.kt
@@ -829,6 +829,7 @@ class ParserTest {
                 batteryOptimizations = 1
                 appHibernation = 1
                 locationPermission = -3
+                remoteConfiguration = 1
               }
         }
     val serialized = message.toJson(parser)
@@ -840,6 +841,7 @@ class ParserTest {
     assertEquals(message.android?.batteryOptimizations, jsonNode.get("android").get("bo").asInt())
     assertEquals(message.android?.appHibernation, jsonNode.get("android").get("hib").asInt())
     assertEquals(message.android?.locationPermission, jsonNode.get("android").get("loc").asInt())
+    assertEquals(message.android?.remoteConfiguration, jsonNode.get("android").get("cmd").asInt())
   }
 
   // endregion


### PR DESCRIPTION
Small addition to the 'status' command to retrieve if 'remoteConfiguration' is allowed.  I added to to a 'cmd' field in the status command.

Useful to determine if the phone can be remotely configured when using it in a centrally managed implementation.

This would be a nice to have on the iOS side as well to track the 'cmd' slider.