### PR TITLE
feat: drop implausible-speed (teleport) locations via heuristic filter

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/preferences/DefaultsProvider.kt
+++ b/project/app/src/main/java/org/owntracks/android/preferences/DefaultsProvider.kt
@@ -45,6 +45,7 @@ interface DefaultsProvider {
       Preferences::locatorInterval -> 60
       Preferences::locatorPriority -> null
       Preferences::useGNSSInSignificantMonitoringMode -> false
+      Preferences::maxImplausibleSpeedKmh -> 0
       Preferences::mode -> ConnectionMode.MQTT
       Preferences::monitoring -> MonitoringMode.Significant
       Preferences::moveModeLocatorInterval -> 10

--- a/project/app/src/main/java/org/owntracks/android/preferences/Preferences.kt
+++ b/project/app/src/main/java/org/owntracks/android/preferences/Preferences.kt
@@ -276,6 +276,10 @@ constructor(
 
   @Preference var mapLayerStyle: MapLayerStyle by preferencesStore
 
+  // Maximum plausible ground speed in km/h between consecutive published fixes. 0 disables the
+  // implausible-speed (teleport) filter.
+  @Preference var maxImplausibleSpeedKmh: Int by preferencesStore
+
   @Preference var mode: ConnectionMode by preferencesStore
 
   @Preference var monitoring: MonitoringMode by preferencesStore

--- a/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.kt
+++ b/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.kt
@@ -62,6 +62,18 @@ internal fun resolveTransitionDebounce(
       null to pending
     }
 
+internal fun isImplausibleSpeed(
+    distanceMeters: Double,
+    timeDeltaMillis: Long,
+    maxSpeedKmh: Int
+): Boolean {
+  if (maxSpeedKmh <= 0 || timeDeltaMillis <= 0) {
+    return false
+  }
+  val speedKmh = (distanceMeters / (timeDeltaMillis / 1000.0)) * 3.6
+  return speedKmh > maxSpeedKmh
+}
+
 @Singleton
 class LocationProcessor
 @Inject
@@ -119,6 +131,25 @@ constructor(
             "Ignoring location from ${location.provider}, last was from gps, and time difference is less than 1s")
         return Result.failure(
             Exception("Ignoring location from ${location.provider}, last was recent and from gps"))
+      }
+    }
+
+    val maxImplausibleSpeedKmh = preferences.maxImplausibleSpeedKmh
+    if (maxImplausibleSpeedKmh > 0 &&
+        trigger != MessageLocation.ReportType.USER &&
+        trigger != MessageLocation.ReportType.CIRCULAR) {
+      locationRepo.currentPublishedLocation.value?.let { lastLocation ->
+        val timeDeltaMillis = location.time - lastLocation.time
+        if (timeDeltaMillis > 0) {
+          val distanceMeters = location.distanceTo(lastLocation)
+          val speedKmh = (distanceMeters.toDouble() / (timeDeltaMillis / 1000.0)) * 3.6
+          if (isImplausibleSpeed(
+              distanceMeters.toDouble(), timeDeltaMillis, maxImplausibleSpeedKmh)) {
+            Timber.d(
+                "Ignoring location from ${location.provider}, implied speed ${speedKmh.roundToInt()}km/h exceeds plausible maximum ${maxImplausibleSpeedKmh}km/h")
+            return Result.failure(Exception("Ignoring location due to implausible speed"))
+          }
+        }
       }
     }
 

--- a/project/app/src/main/java/org/owntracks/android/ui/preferences/load/PreferenceKeyLabels.kt
+++ b/project/app/src/main/java/org/owntracks/android/ui/preferences/load/PreferenceKeyLabels.kt
@@ -33,6 +33,7 @@ val PREFERENCE_KEY_LABELS: Map<String, Int> =
         "locatorInterval" to R.string.preferencesLocatorInterval,
         "locatorPriority" to R.string.preferencesLocatorPriority,
         "mapLayerStyle" to R.string.preferencesMapLayerStyle,
+        "maxImplausibleSpeedKmh" to R.string.preferencesMaxImplausibleSpeedKmh,
         "mode" to R.string.preferencesProfileId,
         "monitoring" to R.string.preferencesMonitoring,
         "moveModeLocatorInterval" to R.string.preferencesMoveModeLocatorInterval,

--- a/project/app/src/main/res/values/strings.xml
+++ b/project/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@ To allow this, please enable Location in the device settings."</string>
     <string name="preferencesInfo">"MQTT info"</string>
     <string name="preferencesLocatorPriority">"Locator priority"</string>
     <string name="preferencesMapLayerStyle">"Map layer"</string>
+    <string name="preferencesMaxImplausibleSpeedKmh">"Maximum plausible speed"</string>
     <string name="preferencesMonitoring">"Monitoring mode"</string>
     <string name="preferencesMqttProtocolLevel">"MQTT protocol level"</string>
     <string name="preferencesNotificationHigherPriority">"High priority notification"</string>

--- a/project/app/src/test/java/org/owntracks/android/services/LocationProcessorTest.kt
+++ b/project/app/src/test/java/org/owntracks/android/services/LocationProcessorTest.kt
@@ -1,0 +1,32 @@
+package org.owntracks.android.services
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocationProcessorTest {
+  @Test
+  fun `given disabled threshold, speed is not implausible`() {
+    assertFalse(isImplausibleSpeed(100000.0, 1000, 0))
+  }
+
+  @Test
+  fun `given plausible slow move, speed is not implausible`() {
+    assertFalse(isImplausibleSpeed(100.0, 60000, 10))
+  }
+
+  @Test
+  fun `given teleport move, speed is implausible`() {
+    assertTrue(isImplausibleSpeed(24140.16, 5000, 500))
+  }
+
+  @Test
+  fun `given zero time delta, speed is not implausible`() {
+    assertFalse(isImplausibleSpeed(1000.0, 0, 10))
+  }
+
+  @Test
+  fun `given negative time delta, speed is not implausible`() {
+    assertFalse(isImplausibleSpeed(1000.0, -1000, 10))
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in implausible-speed (teleport) filter to `LocationProcessor.publishLocationMessage`. When a new fix would imply travel faster than a configurable maximum ground speed relative to the last published location, the fix is dropped before it is queued for sending or persisted as the current published location.

The filter is gated by a new config-import-only integer preference `maxImplausibleSpeedKmh`, defaulting to `0`, which disables the filter and preserves current behaviour. It sits alongside the existing accuracy and network-vs-gps discard heuristics and follows the same `Result.failure` plus Timber logging pattern.

## Why this matters

Users on the OSS (F-Droid/AOSP) flavour report occasional random published locations several miles from the device's true position while the phone is stationary, drawing long straight-line artifacts on the recorder map (#2034, also referenced in #2053). These come from the network/cell-tower provider supplying low-quality fixes that the OSS build forwards without the aggregation Play Services would normally apply.

On 2026-04-30 maintainer @growse scoped the work into two tracked items: (1) Kalman filtering of non-Play-Services locations, and (2) a heuristic to figure out if something looks weirdly wrong and optionally filter it out. This change implements item 2 only. A teleport fix implies an impossible ground speed relative to the previous fix, so dropping fixes above a user-set km/h ceiling removes the artifacts without touching plausible movement.

Behaviour details:
- Strictly opt-in: `maxImplausibleSpeedKmh = 0` (the default) disables the filter.
- Never blocks the first fix (no previous published location to compare against).
- Skips USER and CIRCULAR triggered reports so on-demand and region reports are never suppressed.
- Guards against zero and negative time deltas, so there is no divide-by-zero and a non-advancing clock never drops a fix.

The pure decision lives in an `isImplausibleSpeed(distanceMeters, timeDeltaMillis, maxSpeedKmh)` helper so it can be unit tested without Android dependencies.

## Testing

Added `LocationProcessorTest` with JVM-pure unit tests for the decision helper covering: disabled threshold, a plausible slow move, a teleport (about 15 miles in 5 seconds, implying roughly 17,000 km/h), a zero time delta, and a negative time delta.

Gradle was not run locally because this machine has no Java runtime; CI will validate the build and tests.

Refs #2034
