### PR TITLE
fix(location): stop waypoint region state from bouncing on both flavors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This release addresses a security advisory covering several intent-handling vuln
 - Fix geofences silently failing to register with Google Play Services on devices with significant uptime, due to a `Long.MAX_VALUE` overflow when computing the expiration time (#2245, thanks [@Cooad](https://github.com/Cooad))
 - Waypoint editing had a race when loading the existing waypoint from Room, causing UI overwrites and other inconsistent behaviour. Fixed by only enabling the UI once the waypoint is loaded (#2130)
 - Set the en locale'd strings.xml to be the same as the generic fallback. Hopefully this fixes weirdness on devices with an en-US fallback locale (#2112).
+- Waypoint region state no longer flips back and forth ("bouncing") when a location fix lands near the boundary. GMS builds now rely solely on the native Play Services geofencing API, which already has its own hysteresis, instead of racing it against the app's own per-fix distance check; OSS builds (which have no native geofencing to fall back on) now require a region transition candidate to persist for 2 minutes before it's committed
 
 
 ## Version 2.5.10

--- a/project/app/src/gms/java/org/owntracks/android/di/GeofencingCapabilityModule.kt
+++ b/project/app/src/gms/java/org/owntracks/android/di/GeofencingCapabilityModule.kt
@@ -1,0 +1,15 @@
+package org.owntracks.android.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+
+@InstallIn(SingletonComponent::class)
+@Module
+object GeofencingCapabilityModule {
+  @Provides
+  @Named("nativeGeofencingAvailable")
+  fun provideNativeGeofencingAvailable(): Boolean = true
+}

--- a/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.kt
+++ b/project/app/src/main/java/org/owntracks/android/services/LocationProcessor.kt
@@ -2,6 +2,7 @@ package org.owntracks.android.services
 
 import android.location.Location
 import android.os.Build
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -34,6 +35,33 @@ import org.owntracks.android.support.MessageWaypointCollection
 import org.owntracks.android.test.SimpleIdlingResource
 import timber.log.Timber
 
+/**
+ * A waypoint transition candidate that has been observed but not yet committed, because it hasn't
+ * persisted for long enough to rule out a fix landing right on the waypoint boundary.
+ */
+internal data class PendingWaypointTransition(val transition: Int, val since: Instant)
+
+/**
+ * Debounces a waypoint transition candidate against previously-pending state. A candidate is only
+ * committed once it has been observed consistently for at least [dwell]; a candidate that differs
+ * from the currently-pending one resets the dwell timer.
+ *
+ * @return a pair of (transition to commit, if any) to (new pending state, if any)
+ */
+internal fun resolveTransitionDebounce(
+    pending: PendingWaypointTransition?,
+    candidate: Int,
+    now: Instant,
+    dwell: Duration
+): Pair<Int?, PendingWaypointTransition?> =
+    if (pending == null || pending.transition != candidate) {
+      null to PendingWaypointTransition(candidate, now)
+    } else if (Duration.between(pending.since, now) >= dwell) {
+      candidate to null
+    } else {
+      null to pending
+    }
+
 @Singleton
 class LocationProcessor
 @Inject
@@ -49,7 +77,8 @@ constructor(
   @param:Named("publishResponseMessageIdlingResource")
     private val publishResponseMessageIdlingResource: SimpleIdlingResource,
   @param:Named("mockLocationIdlingResource")
-    private val mockLocationIdlingResource: SimpleIdlingResource
+    private val mockLocationIdlingResource: SimpleIdlingResource,
+  @param:Named("nativeGeofencingAvailable") private val nativeGeofencingAvailable: Boolean
 ) {
   private fun locationIsWithAccuracyThreshold(l: Location): Boolean =
       preferences.ignoreInaccurateLocations
@@ -65,6 +94,11 @@ constructor(
       locationRepo.currentPublishedLocation.value?.run { publishLocationMessage(trigger, this) }
 
   private val highAccuracyProviders = setOf("gps", "fused")
+
+  // Matches the notificationResponsiveness used for native GMS geofencing, so both flavors have
+  // comparable real-world hysteresis around a waypoint boundary.
+  private val transitionDebounceDwell: Duration = Duration.ofMinutes(2)
+  private val pendingWaypointTransitions = mutableMapOf<Long, PendingWaypointTransition>()
 
   private suspend fun publishLocationMessage(
       trigger: MessageLocation.ReportType,
@@ -91,24 +125,48 @@ constructor(
     val loadedWaypoints = withContext(ioDispatcher) { waypointsRepo.getAll() }
     Timber.d("publishLocationMessage for $location triggered by $trigger")
 
-    // Check if publish would trigger a region if fusedRegionDetection is enabled
+    // Check if publish would trigger a region if fusedRegionDetection is enabled. Skipped entirely
+    // where native OS geofencing is available (e.g. gms) - that's a purpose-built mechanism with its
+    // own hysteresis, and running this alongside it causes the two to race and flip-flop on the same
+    // waypoint state. Where it isn't available (e.g. oss), a transition candidate must instead be
+    // observed consistently for transitionDebounceDwell before being committed, for the same reason.
     Timber.d(
-        "Checking if location triggers waypoint transitions. waypoints: $loadedWaypoints, trigger=$trigger, fusedRegionDetection: ${preferences.fusedRegionDetection}")
+        "Checking if location triggers waypoint transitions. waypoints: $loadedWaypoints, trigger=$trigger, fusedRegionDetection: ${preferences.fusedRegionDetection}, nativeGeofencingAvailable: $nativeGeofencingAvailable")
     if (loadedWaypoints.isNotEmpty() &&
         preferences.fusedRegionDetection &&
+        !nativeGeofencingAvailable &&
         trigger != MessageLocation.ReportType.CIRCULAR) {
+      pendingWaypointTransitions.keys.retainAll(loadedWaypoints.map { it.id }.toSet())
       loadedWaypoints.forEach { waypoint ->
-        Timber.d("onWaypointTransition triggered by location waypoint intersection event")
-        onWaypointTransition(
-            waypoint,
-            location,
+        val candidate =
             if (location.distanceTo(waypoint.getLocation()) <=
                 waypoint.geofenceRadius + location.accuracy) {
               Geofence.GEOFENCE_TRANSITION_ENTER
             } else {
               Geofence.GEOFENCE_TRANSITION_EXIT
-            },
-            MessageTransition.TRIGGER_LOCATION)
+            }
+        if (candidate == waypoint.lastTransition) {
+          pendingWaypointTransitions.remove(waypoint.id)
+          Timber.d("onWaypointTransition triggered by location waypoint intersection event")
+          onWaypointTransition(waypoint, location, candidate, MessageTransition.TRIGGER_LOCATION)
+        } else {
+          val (transitionToCommit, newPending) =
+              resolveTransitionDebounce(
+                  pendingWaypointTransitions[waypoint.id],
+                  candidate,
+                  Instant.ofEpochMilli(location.time),
+                  transitionDebounceDwell)
+          if (newPending == null) {
+            pendingWaypointTransitions.remove(waypoint.id)
+          } else {
+            pendingWaypointTransitions[waypoint.id] = newPending
+          }
+          if (transitionToCommit != null) {
+            Timber.d("onWaypointTransition triggered by location waypoint intersection event")
+            onWaypointTransition(
+                waypoint, location, transitionToCommit, MessageTransition.TRIGGER_LOCATION)
+          }
+        }
       }
     }
     if (preferences.monitoring === MonitoringMode.Quiet &&

--- a/project/app/src/oss/java/org/owntracks/android/di/GeofencingCapabilityModule.kt
+++ b/project/app/src/oss/java/org/owntracks/android/di/GeofencingCapabilityModule.kt
@@ -1,0 +1,15 @@
+package org.owntracks.android.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+
+@InstallIn(SingletonComponent::class)
+@Module
+object GeofencingCapabilityModule {
+  @Provides
+  @Named("nativeGeofencingAvailable")
+  fun provideNativeGeofencingAvailable(): Boolean = false
+}

--- a/project/app/src/test/java/org/owntracks/android/services/LocationProcessorTransitionDebounceTest.kt
+++ b/project/app/src/test/java/org/owntracks/android/services/LocationProcessorTransitionDebounceTest.kt
@@ -1,0 +1,58 @@
+package org.owntracks.android.services
+
+import java.time.Duration
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.owntracks.android.location.geofencing.Geofence
+
+class LocationProcessorTransitionDebounceTest {
+  private val dwell: Duration = Duration.ofMinutes(2)
+  private val t0: Instant = Instant.parse("2026-07-20T10:00:00Z")
+
+  @Test
+  fun `first candidate observed starts the timer without committing`() {
+    val (transitionToCommit, pending) =
+        resolveTransitionDebounce(null, Geofence.GEOFENCE_TRANSITION_EXIT, t0, dwell)
+
+    assertNull(transitionToCommit)
+    assertEquals(PendingWaypointTransition(Geofence.GEOFENCE_TRANSITION_EXIT, t0), pending)
+  }
+
+  @Test
+  fun `same candidate before dwell elapses does not commit`() {
+    val pendingSince = PendingWaypointTransition(Geofence.GEOFENCE_TRANSITION_EXIT, t0)
+    val now = t0.plus(dwell.minusSeconds(1))
+
+    val (transitionToCommit, pending) =
+        resolveTransitionDebounce(pendingSince, Geofence.GEOFENCE_TRANSITION_EXIT, now, dwell)
+
+    assertNull(transitionToCommit)
+    assertEquals(pendingSince, pending)
+  }
+
+  @Test
+  fun `same candidate once dwell elapses commits and clears pending`() {
+    val pendingSince = PendingWaypointTransition(Geofence.GEOFENCE_TRANSITION_EXIT, t0)
+    val now = t0.plus(dwell)
+
+    val (transitionToCommit, pending) =
+        resolveTransitionDebounce(pendingSince, Geofence.GEOFENCE_TRANSITION_EXIT, now, dwell)
+
+    assertEquals(Geofence.GEOFENCE_TRANSITION_EXIT, transitionToCommit)
+    assertNull(pending)
+  }
+
+  @Test
+  fun `candidate flip before commit resets the timer to the new candidate`() {
+    val pendingSince = PendingWaypointTransition(Geofence.GEOFENCE_TRANSITION_EXIT, t0)
+    val now = t0.plusSeconds(90)
+
+    val (transitionToCommit, pending) =
+        resolveTransitionDebounce(pendingSince, Geofence.GEOFENCE_TRANSITION_ENTER, now, dwell)
+
+    assertNull(transitionToCommit)
+    assertEquals(PendingWaypointTransition(Geofence.GEOFENCE_TRANSITION_ENTER, now), pending)
+  }
+}


### PR DESCRIPTION
Two independent, uncoordinated detectors were both driving waypoint
transitions: the native Play Services geofencing API (with real hysteresis)
and LocationProcessor's own per-fix distance check (with none), racing on
the same WaypointModel.lastTransition and causing region-boundary
"bouncing" for fixes landing near a waypoint's edge.

GMS builds now rely solely on native geofencing for region detection,
via a new per-flavor nativeGeofencingAvailable capability binding that
disables the app-level heuristic there entirely. OSS builds have no
native fallback, so instead a transition candidate there must now be
observed consistently for 2 minutes (matching native geofencing's own
dwell time) before it's committed.
