### PR TITLE
Fix flakeyness in MessageProcessorTest due to race conditions

### DIFF
--- a/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.kt
+++ b/project/app/src/main/java/org/owntracks/android/services/MessageProcessor.kt
@@ -346,14 +346,6 @@ constructor(
 
   // Should be on the background thread here, because we block
   private suspend fun sendAvailableMessages() {
-    /*
-    Whether a loop is alive is tracked by dequeueAndSenderJob in startSendingMessages, which is the
-    only thing that launches this — that, not the mutex, is the liveness check. The previous
-    `if (mutex.isLocked) return` was both TOCTOU-racy and the wrong question: a loop that lost the
-    race silently gave up and was never restarted. The mutex now only serialises the handover, so a
-    replacement loop cannot start consuming the queue before a cancelled one has finished
-    unwinding.
-     */
     outboundMessageQueueMutex.withLock {
       // The loop can be started before the queue has finished loading off disk.
       queueInitJob.join()
@@ -672,10 +664,12 @@ constructor(
   suspend fun publishLocationMessage(trigger: MessageLocation.ReportType) {
     locationProcessorLazy.get().publishLocationMessage(trigger)
   }
-
   fun stopSendingMessages() {
     Timber.d("Interrupting background sending thread")
-    dequeueAndSenderJob?.cancel()
+    dequeueAndSenderJob?.also { job ->
+      job.cancel()
+      runBlocking { job.join() }
+    }
   }
 
   override fun onPreferenceChanged(properties: Set<String>) {

--- a/project/app/src/test/java/org/owntracks/android/services/MessageProcessorTest.kt
+++ b/project/app/src/test/java/org/owntracks/android/services/MessageProcessorTest.kt
@@ -53,6 +53,13 @@ import org.owntracks.android.test.ThresholdIdlingResourceInterface
  * The loop itself is private, so these tests observe it through the queue: a live loop parks in
  * [AsyncDeQueue.awaitMessage] waiting for work, so reaching that call is the signal that the loop is
  * running.
+ *
+ * Every detector must be armed *before* the action that's expected to trigger it, never after:
+ * `awaitMessage` is called once per loop start and then parks forever on an empty channel, so a
+ * detector armed too late can miss a loop that reaches it first on its own dispatcher thread —
+ * nothing will ever call `awaitMessage` again to satisfy a detector that showed up afterwards. This
+ * bit the setup steps in several tests here, not just the assertion under test, because a lost race
+ * in setup still fails the test — just with a less obvious message.
  */
 class MessageProcessorTest {
 
@@ -158,8 +165,9 @@ class MessageProcessorTest {
 
   @Test
   fun `stopSendingMessages stops the outbound sender loop`() {
+    val startDetector = queue.armLoopDetector()
     messageProcessor.initialize()
-    assertLoopRunning(queue.armLoopDetector(), "sender loop should be running after initialize")
+    assertLoopRunning(startDetector, "sender loop should be running after initialize")
 
     messageProcessor.stopSendingMessages()
 
@@ -178,8 +186,9 @@ class MessageProcessorTest {
    */
   @Test
   fun `initialize re-arms the sender loop after the background service is destroyed and recreated`() {
+    val startDetector = queue.armLoopDetector()
     messageProcessor.initialize() // service starts
-    assertLoopRunning(queue.armLoopDetector(), "sender loop should be running after initialize")
+    assertLoopRunning(startDetector, "sender loop should be running after initialize")
 
     messageProcessor.stopSendingMessages() // BackgroundService.onDestroy
 
@@ -192,8 +201,9 @@ class MessageProcessorTest {
   /** Whatever triggered the reconnect, the queue still needs something alive to drain it. */
   @Test
   fun `reconnect re-arms the sender loop`() {
+    val startDetector = queue.armLoopDetector()
     messageProcessor.initialize()
-    assertLoopRunning(queue.armLoopDetector(), "sender loop should be running after initialize")
+    assertLoopRunning(startDetector, "sender loop should be running after initialize")
 
     messageProcessor.stopSendingMessages()
 
@@ -209,8 +219,9 @@ class MessageProcessorTest {
    */
   @Test
   fun `repeated initialize calls do not start a second loop`() {
+    val startDetector = queue.armLoopDetector()
     messageProcessor.initialize()
-    assertLoopRunning(queue.armLoopDetector(), "sender loop should be running after initialize")
+    assertLoopRunning(startDetector, "sender loop should be running after initialize")
 
     // Already-running loop is parked in awaitMessage; a second loop would have to call it again.
     val detector = queue.armLoopDetector()
@@ -231,8 +242,9 @@ class MessageProcessorTest {
    */
   @Test
   fun `checkConnection reports healthy for an endpoint with no persistent connection`() {
+    val startDetector = queue.armLoopDetector()
     messageProcessor.initialize() // preferences.mode is HTTP
-    assertLoopRunning(queue.armLoopDetector(), "sender loop should be running after initialize")
+    assertLoopRunning(startDetector, "sender loop should be running after initialize")
 
     runBlocking { assertTrue(messageProcessor.checkConnection()) }
   }


### PR DESCRIPTION
Two distinct sources of flakiness in the sender-loop lifecycle tests:

1. stopSendingMessages() only requested cancellation and returned
   immediately, without waiting for the cancelled job to actually
   release outboundMessageQueueMutex. A caller that immediately
   restarts the loop afterwards (as several tests, and a real
   destroy/recreate cycle, do) then races the old job's teardown for
   the mutex, with no bound on how long that takes under CPU
   contention. stopSendingMessages() now joins the cancelled job
   before returning, so "stopped" means the mutex is actually free.

2. Several tests armed their setup-precondition loop detector *after*
   calling initialize(), the same arm-after-acting race already fixed
   for the assertion-under-test case in 2884e82a: initialize() launches
   asynchronously, so a loop that reaches awaitMessage before the
   detector exists is never observed, and the test hangs until timeout.
   Armed all of them before acting instead, matching the tests that
   were already safe.
